### PR TITLE
N30N C1RCUS: twins

### DIFF
--- a/contribution/notes/files/N30N_pachinko.md
+++ b/contribution/notes/files/N30N_pachinko.md
@@ -26,6 +26,6 @@ _"Tripp"_
 
 She half-listened as they moved away, rabbiting on about crits and BTC. Boy talk. 15 pages later she sighed, put the book down, because clearly Anna was not going to jump Alexei any time soon, and wandered down to reset the machine.
 
-Out of habit she glanced at the score list. `TRPLHLX`. Dude was clearly a bit shy around vowels and girls, and then narrowed her eyes at the actual score. Vowels or no vowels, the guy must have the reflexes of a cat. _"Bet I could make him purr like one too"_ she giggled.
+Out of habit she glanced at the score list. `TRPLHLX`. Dude seemed to be a bit shy around vowels and girls. And then narrowed her eyes at the actual score. Vowels or no vowels, the guy must have the reflexes of a cat. _"Bet I could make him purr like one too"_ she giggled.
 
 She gave the machine a wipe and went back to snow falling in Moscow. Maybe he'd be back. Maybe he wouldn't.

--- a/contribution/notes/files/N30N_twins.md
+++ b/contribution/notes/files/N30N_twins.md
@@ -1,0 +1,25 @@
+#### N30N C1RCUS: The Twins
+
+_"It was a dark and stormy night.."_
+
+_Al_ looked across at his twin - in truth, there was nobody he would rather mission with, but every now and then _Beta_ just **totally** weirded him out.
+
+The _Ice_ twins were in the shadows on the top floor'ish-thing of the building skeleton that overlooked a south side warehouse, the _Spud_ having asked them to provide _'tactical street oversight'_ (his words) for a delivery of meds he was expecting. _PotatoMan_ had taken advantage of the recent batch of dud _PainAway_ that hit the street to launch his own premium brand, little logo and everything. This was the first shipment and he was a little nervous.
+
+Movement..
+
+_"Crate, east side"_  
+_"See it. Barrels 10 metres down"_  
+_"On it"_  
+_..._
+
+A round ricocheted off the column above _Al_'s head. _"10 o'clock, tenement roof"_ _"Go"_. _Al_ moved quickly, making sure he was silhouetted for a brief moment and _Beta_ tagged the sniper. Down at the warehouse it had basically degenerated into trench warfare. 
+
+_"Street"_
+
+He sprinted along the ledge and leaped, deploying the matte black combat canopy almost immediately. The building was just barely high enough, leaving not very much margin for error. Kinda like life really. _Beta_ touched down just behind him and they leap-frogged up the street to come up just behind the goons. 
+
+After that there wasn't much else to do:
+
+_"Go get that beer the 'tater now owes us?"_  
+_"Yup, shaken not stirred"_ said _Beta_ happily. Being all weird again.

--- a/contribution/notes/index.json
+++ b/contribution/notes/index.json
@@ -22,6 +22,7 @@
 		"Marina4",
 		"N30N_angel",
 		"N30N_pachinko",
+		"N30N_twins",
 		"NewAgeNote1",
 		"NewAgeNote2",
 		"NewAgeNote3",


### PR DESCRIPTION
1. Tidied up phrasing for N30N C1RCUS pachinko background story
2. Added side story for `alfaice`