### PR TITLE
Credits.md

### DIFF
--- a/Credits.md
+++ b/Credits.md
@@ -78,7 +78,7 @@ zomg
 [DexterHuang](https://github.com/DexterHuang)  
 Dzylx  
 [HBUnknown](https://www.facebook.com/john.bostwick.31)  
-Living Dead
+Living Dead  
 [Misaki](https://github.com/Misaki290)  
 [Omnipotent_God](https://github.com/Omnipotent-God)  
 [s3rvant](https://github.com/s3rvant)  


### PR DESCRIPTION
Added 2 spaces after "Living Dead" since it appeared as "Living Dead Misaki" in the credits.
My name is not Living Dead Misaki.
Just wanted to correct the small typo.