### PR TITLE
Correction of typos, minor changes and translation

### DIFF
--- a/contribution/lang/ru.json
+++ b/contribution/lang/ru.json
@@ -36,7 +36,7 @@
  	 	},
  	 	"medical": {
  	 	 	"name": {
- 	 	 	 	"trans": "создание медицинских припасов",
+ 	 	 	 	"trans": "создание медикаментов",
  	 	 	 	"eng": "medical science"
  	 	 	}
  	 	},
@@ -95,7 +95,7 @@
  	 	 	},
  	 	 	"toMarket": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Направиться на Торговую площадь Шангри-Ла",
+ 	 	 	 	 	"trans": "Направиться на Торг. площадь Шангри-Ла",
  	 	 	 	 	"eng": "Go to Shangri-La Market Street"
  	 	 	 	},
  	 	 	 	"tut": {
@@ -115,7 +115,7 @@
  	 	 	},
  	 	 	"toMainHub": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Вернуться в Центральный район Шангри-Ла",
+ 	 	 	 	 	"trans": "Вернуться в Центр. район Шангри-Ла",
  	 	 	 	 	"eng": "Return to Shangri-La City Center"
  	 	 	 	}
  	 	 	}
@@ -257,7 +257,7 @@
  	 	},
  	 	"printer": {
  	 	 	"name": {
- 	 	 	 	"trans": "Молекулярный 3D Принтер",
+ 	 	 	 	"trans": "Молекулярны 3D Принтер",
  	 	 	 	"eng": "Molecular 3d Printer"
  	 	 	},
  	 	 	"tut": {
@@ -311,7 +311,7 @@
  	 	},
  	 	"increaseMedical": {
  	 	 	"name": {
- 	 	 	 	"trans": "Взлом Клиники модификаций тела",
+ 	 	 	 	"trans": "Взлом Клиники Модификаций Тела",
  	 	 	 	"eng": "Hack a Body Mod Clinic"
  	 	 	},
  	 	 	"description": {
@@ -685,7 +685,7 @@
  	 	 	 	"eng": "Experience Memory"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Жесткий диск, хранящий чьи-то воспоминания; при использовании будет получен опытт",
+ 	 	 	 	"trans": "Жесткий диск, хранящий чьи-то воспоминания; при использовании будет получен опыт",
  	 	 	 	"eng": "Memory bank contains someone's memory, if used you may gain experience from this"
  	 	 	}
  	 	},
@@ -725,7 +725,7 @@
  	 	 	 	"eng": "Frontal Cortex Optimization Transmitter"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Транслирует коды взлома всем кибернетически связанным пользователям, усиливая соединение их лобной коры с установленными в нее кибер-программами, тем самым увеличивая объем памяти пользователя.\r\n\r\n        При использовании дает глобальное ускорение всем игрокам онлайн, увеличивая полученный опыт на 80% в течение 20 минут\r\n        ",
+ 	 	 	 	"trans": "Транслирует коды взлома всем кибернетически связанным пользователям, усиливая соединение их лобной коры с установленными в нее кибер-программами, тем самым увеличивая объем памяти пользователя.\r\n\r\n        При использовании дает глобальное ускорение всем игрокам онлайн, увеличивая получаемый опыт на 80% в течение 20 минут\r\n        ",
  	 	 	 	"eng": "Broadcasts exploits to all cybernetically connected users, enhance their Frontal Cortex integration with cyberwares installed, thus increase memory capability of the user.\r\n\r\n        When used, gives Global Buff to all players online, increase EXP gained to 180% for 20 minutes\r\n        "
  	 	 	}
  	 	},
@@ -819,31 +819,31 @@
  	 	},
  	 	"lootBox1": {
  	 	 	"name": {
- 	 	 	 	"trans": "locked container",
+ 	 	 	 	"trans": "запертый контейнер",
  	 	 	 	"eng": "locked container"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container",
+ 	 	 	 	"trans": "Усиленный контейнер с биометрическим замком шифрования, похоже, содержит важные предметы внутри.\r\n        К счастью, плата микрокомпьютера работает на устаревшей прошивке, где возможен эксплойт, перейдите в [Терминал], чтобы открыть этот контейнер",
  	 	 	 	"eng": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container"
  	 	 	}
  	 	},
  	 	"lootBox2": {
  	 	 	"name": {
- 	 	 	 	"trans": "locked rare container",
+ 	 	 	 	"trans": "запертый редкий контейнер",
  	 	 	 	"eng": "locked rare container"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container",
+ 	 	 	 	"trans": "Усиленный контейнер с биометрическим замком шифрования, похоже, содержит важные предметы внутри.\r\n        К счастью, плата микрокомпьютера работает на устаревшей прошивке, где возможен эксплойт, перейдите в [Терминал], чтобы открыть этот контейнер",
  	 	 	 	"eng": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container"
  	 	 	}
  	 	},
  	 	"lootBox3": {
  	 	 	"name": {
- 	 	 	 	"trans": "locked legendary container",
+ 	 	 	 	"trans": "запертый легендарный контейнер",
  	 	 	 	"eng": "locked legendary container"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container",
+ 	 	 	 	"trans": "Усиленный контейнер с биометрическим замком шифрования, похоже, содержит важные предметы внутри.\r\n        К счастью, плата микрокомпьютера работает на устаревшей прошивке, где возможен эксплойт, перейдите в [Терминал], чтобы открыть этот контейнер",
  	 	 	 	"eng": "A reinforced container with biometric encryption lock, it seems to contain important items inside.\r\n        Luckily the on board micro computer is running on out-dated firmware, where an exploit is possible, go to [Terminal] to unlock this container"
  	 	 	}
  	 	}
@@ -1208,11 +1208,11 @@
  	 	 	"eng": "Confirm"
  	 	},
  	 	"requires": {
- 	 	 	"trans": "Requires",
+ 	 	 	"trans": "Требуется",
  	 	 	"eng": "Requires"
  	 	},
  	 	"receives": {
- 	 	 	"trans": "Receives",
+ 	 	 	"trans": "Получите",
  	 	 	"eng": "Receives"
  	 	},
  	 	"amount": {
@@ -1349,7 +1349,7 @@
  	 	},
  	 	"damageMultiplier": {
  	 	 	"name": {
- 	 	 	 	"trans": "Множитель Здоровья",
+ 	 	 	 	"trans": "Множитель Урона",
  	 	 	 	"eng": "Damage multiplier"
  	 	 	},
  	 	 	"description": {
@@ -1433,7 +1433,7 @@
  	 	 	 	"eng": "Max Health"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Кол-во здоровья игрока",
+ 	 	 	 	"trans": "Максимальный объём здоровья",
  	 	 	 	"eng": "Maximum health capacity"
  	 	 	}
  	 	}
@@ -1444,7 +1444,7 @@
  	 	 	 	"verb",
  	 	 	 	"amount"
  	 	 	],
- 	 	 	"trans": "You can ${verb} ${amount} times",
+ 	 	 	"trans": "Ты можешь ${verb} ${amount} раз",
  	 	 	"eng": "You can ${verb} ${amount} times"
  	 	},
  	 	"timeRequiredText": {
@@ -1452,30 +1452,30 @@
  	 	 	 	"verb",
  	 	 	 	"timeStr"
  	 	 	],
- 	 	 	"trans": "Time required to ${verb}: ${timeStr}",
+ 	 	 	"trans": "Время, необходимое для ${verb}: ${timeStr}",
  	 	 	"eng": "Time required to ${verb}: ${timeStr}"
  	 	}
  	},
  	"recipe": {
  	 	"unlockLootBox1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Unlock Container",
+ 	 	 	 	"trans": "Открыть Контейнер",
  	 	 	 	"eng": "Unlock Container"
  	 	 	}
  	 	},
  	 	"unlock": {
- 	 	 	"trans": "Unlock",
+ 	 	 	"trans": "Открыть",
  	 	 	"eng": "Unlock"
  	 	},
  	 	"unlockLootBox2": {
  	 	 	"name": {
- 	 	 	 	"trans": "Unlock Rare Container",
+ 	 	 	 	"trans": "Открыть Редкий Контейнер",
  	 	 	 	"eng": "Unlock Rare Container"
  	 	 	}
  	 	},
  	 	"unlockLootBox3": {
  	 	 	"name": {
- 	 	 	 	"trans": "Unlock Legendary Container",
+ 	 	 	 	"trans": "Открыть Легендарный Контейнер",
  	 	 	 	"eng": "Unlock Legendary Container"
  	 	 	}
  	 	}
@@ -1487,18 +1487,18 @@
  	 	 	 	"priceStr",
  	 	 	 	"itemName"
  	 	 	],
- 	 	 	"trans": "You are selling ${amountStr} ${itemName}(s), at the price of ${priceStr} Per Item",
+ 	 	 	"trans": "Ты продаёшь ${amountStr} ${itemName}(s), по цене ${priceStr} за штуку",
  	 	 	"eng": "You are selling ${amountStr} ${itemName}(s), at the price of ${priceStr} Per Item"
  	 	},
  	 	"totalConfirm": {
  	 	 	"vars": [
  	 	 	 	"total"
  	 	 	],
- 	 	 	"trans": "If all of them are sold, you will earn ${total} BitCoins",
+ 	 	 	"trans": "Если всё будет продано, то ты получишь ${total} Биткоинов",
  	 	 	"eng": "If all of them are sold, you will earn ${total} BitCoins"
  	 	},
  	 	"sellAmountModalTitle": {
- 	 	 	"trans": "How many would you like to sell?",
+ 	 	 	"trans": "Сколько ты хочешь продать?",
  	 	 	"eng": "How many would you like to sell?"
  	 	}
  	}


### PR DESCRIPTION
39: 
https://prnt.sc/12k9mt8
In 3 lines, it looks terrible. Nothing has changed in the context, but it will look better
98:
https://prnt.sc/12k9spv
The hyphenation of the name looks terrible
118:
https://prnt.sc/12k9zhy
Same thing as with 98
260:
https://prnt.sc/12ka2xa
The transfer of one letter looks just disgusting. It is better to simply delete it. There will be a feeling that the girl's head is blocking the word.
314, 688, 728:
Just little remark
1352:
It was necessary to translate "Damage multiplier". Translated, literally "Health multiplier". Now the translation is correct
1436:
It was necessary to translate "Maximum health capacity". Translated, literally "The player's health count". Now the translation is correct
822, 826, 832, 836, 842, 846, 1211, 1215, 1447, 1455, 1462, 1467, 1472, 1478, 1490, 1497, 1501:
Translation into Russian