### PR TITLE
Update word filter.

### DIFF
--- a/contribution/word-filter.json
+++ b/contribution/word-filter.json
@@ -14,6 +14,8 @@
     "communist",
     "pedophile",
     "pedo",
-    "rape"
+    "rape",
+    "masturbation",
+    "masturbate"
   ]
 }


### PR DESCRIPTION
Uh yeah, this needs to be banned. If we're banning sex we might as well ban words whose definitions literally include the word. I mean sure it is safe in a sense (some start this at a young age), but if we're considering CCO to be PG-13 (from the fact the f word is banned, which happens to be both an expression and just simply unsafe) then yeahhh, NOT SAFE. 

For reference:
mas·tur·ba·tion
/ˌmastərˈbāSHən/
noun
stimulation of the genitals with the hand for sexual pleasure.