### PR TITLE
Create Biofinance8.md

### DIFF
--- a/contribution/notes/files/Biofinance8.md
+++ b/contribution/notes/files/Biofinance8.md
@@ -1,0 +1,13 @@
+[A display is showing financial news]
+
+Today spotlight is on the biohazard accident that hit IntelliCo. Neural Implants Manufacturing Facility in Shangri-La Depot 33 district.
+
+Police is blaming human error, apparently originating from the company lax safety practices released an airborne nerve agent in the office building. 
+
+400 employees are dead, among them the whole research department. A serious blow for the rapidly growing company.
+
+IntelliCo. shares went down 98% in a matter of hours, with little to none chance of recovery in sight.
+
+[on the news ticker]
+
+*###eds dead in Vitasyntech lab accident. Facility burned to ground in flash fir###*


### PR DESCRIPTION
[A display is showing financial news]

Today spotlight is on the biohazard accident that hit IntelliCo. Neural Implants Manufacturing Facility in Shangri-La Depot 33 district.
Police is blaming human error, apparently originating from the company lax safety practices. A faulty procedure released an airborne nerve agent in the office building. 
400 employees are dead, among them the whole research department. A serious blow for the rapidly growing company.
IntelliCo. shares went down 98% in a matter of hours, with little to no chance of recovery in sight.

[on the news ticker]
###eds dead in Vitasyntech lab accident. Facility burned to ground in flash fir###