### PR TITLE
fix typo

### DIFF
--- a/contribution/lang/ru.json
+++ b/contribution/lang/ru.json
@@ -907,7 +907,7 @@
  	 	},
  	 	"ammo1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Энергочейка",
+ 	 	 	 	"trans": "Энергоячейка",
  	 	 	 	"eng": "Energy Cell"
  	 	 	},
  	 	 	"description": {


### PR DESCRIPTION
Fixed typo in Energy cell translation to russian.
Cell is 'ячейка', not 'чейка'