### PR TITLE
Update ja.json

### DIFF
--- a/contribution/lang/ja.json
+++ b/contribution/lang/ja.json
@@ -5215,7 +5215,7 @@
  	 	 	 	 	"name",
  	 	 	 	 	"traitFix"
  	 	 	 	],
- 	 	 	 	"trans": "${tierPart} ${name} ${traitFix}",
+ 	 	 	 	"trans": "${tierPart} ${traitFix} ${name}",
  	 	 	 	"eng": "${tierPart} ${name} ${traitFix}"
  	 	 	},
  	 	 	"noTrait": {


### PR DESCRIPTION
日本語は英語と文法が異なり"itemTrait"が文末だと違和感があるため語順を修正
== DeepL ==
The grammar of Japanese is different from English, and it feels strange to have "itemTrait" at the end of a sentence, so the word order was modified.

ex.)
Gun of Stun
↓  DeepL
スタンの(of Stun) 銃(Gun)