### PR TITLE
Update Pain Away in ES

### DIFF
--- a/contribution/lang/es.json
+++ b/contribution/lang/es.json
@@ -559,11 +559,11 @@
  	 	},
  	 	"healing1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Pain Away",
+ 	 	 	 	"trans": "Medicina",
  	 	 	 	"eng": "Pain Away"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "¿Te duele la cabeza? ¡Usa Pain Away™ para aliviar tu dolor!",
+ 	 	 	 	"trans": "¿Te duele la cabeza? ¡Usa la Medicina Pain Away™ para aliviar tu dolor!",
  	 	 	 	"eng": "Do you have headache? Use Pain Away™ to relieve your pain!"
  	 	 	}
  	 	},
@@ -639,11 +639,11 @@
  	 	},
  	 	"healingArea1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Pain Away Spray",
+ 	 	 	 	"trans": "Medicina Spray",
  	 	 	 	"eng": "Pain Away Spray"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "¿Tus amigos y tú tienen dolor de cabeza? ¡Usa Pain Away Spray™ para aliviar su dolor!",
+ 	 	 	 	"trans": "¿Tus amigos y tú tienen dolor de cabeza? ¡Usa la Medicina Pain Away Spray™ para aliviar su dolor!",
  	 	 	 	"eng": "Do you and your friends both have headaches? Use Pain Away Spray™ to relief your pain!"
  	 	 	}
  	 	},
@@ -3062,7 +3062,7 @@
  	 	 	 	"trans": "¿Tal vez compra algún artículo curativo primero?",
  	 	 	 	"eng": "Maybe buy some healing item first?",
  	 	 	 	"des": {
- 	 	 	 	 	"trans": "Parece que no tienes ningún Pain Away contigo, compralos en el Mercado Trinoky en la ciudad antes de entrar en Mazmorras, ya que no te regenerás después de las peleas en la mazmorra",
+ 	 	 	 	 	"trans": "Parece que no tienes ningúna Medicina Pain Away contigo, compralos en el Mercado Trinoky en la ciudad antes de entrar en Mazmorras, ya que no te regenerás después de las peleas en la mazmorra",
  	 	 	 	 	"eng": "Seems like you dont have any Pain Away with you, purchase it from Trinoky Mart in the city first before entering dungeons, since you will not regen after battles in dungeon"
  	 	 	 	},
  	 	 	 	"cancel": {


### PR DESCRIPTION
The name of "Pain Away" remains in English in the Spanish language and I suggest the following name as "Medicina" Keeping "Pain Away" as a brand