### PR TITLE
Update - LevelUp bug

### DIFF
--- a/contribution/lang/es.json
+++ b/contribution/lang/es.json
@@ -3952,7 +3952,7 @@
  	 	 	 	 	"from",
  	 	 	 	 	"to"
  	 	 	 	],
- 	 	 	 	"trans": "${de} => ${a}",
+ 	 	 	 	"trans": "${from} => ${to}",
  	 	 	 	"eng": "${from} => ${to}"
  	 	 	}
  	 	},
@@ -4038,7 +4038,7 @@
  	 	 	 	 	"from",
  	 	 	 	 	"to"
  	 	 	 	],
- 	 	 	 	"trans": "${de} => ${a}",
+ 	 	 	 	"trans": "${from} => ${to}",
  	 	 	 	"eng": "${from} => ${to}"
  	 	 	}
  	 	},


### PR DESCRIPTION
In the Spanish language, when leveling up it showed "${De} => ${A}", and not the correct numbers, I corrected the code, now it is "${from} => ${to}" so that now if we can visualize the numbers well.