### PR TITLE
Technical translation error

### DIFF
--- a/contribution/lang/fr.json
+++ b/contribution/lang/fr.json
@@ -822,21 +822,21 @@
  	 	},
  	 	"ammoTech1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Pièces de munitions tech",
+ 	 	 	 	"trans": "Pièces techniques de munitions",
  	 	 	 	"eng": "Ammunition tech parts"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Pièces de munitions tech, celles-ci peuvent être couramment trouvées circulant sur le marché noir. \r\n        Vous pouvez les utiliser pour fabriquer des munitions si vous savez comment.",
+ 	 	 	 	"trans": "Pièces techniques de munitions, celles-ci peuvent être couramment trouvées circulant sur le marché noir. \r\n        Vous pouvez les utiliser pour fabriquer des munitions si vous savez comment.",
  	 	 	 	"eng": "Ammunition tech parts, These can be commonly found circulating the black market. \r\n        You can use these to craft ammunition if you understand how."
  	 	 	}
  	 	},
  	 	"ammoTech2": {
  	 	 	"name": {
- 	 	 	 	"trans": "Pièces de munitions tech Militaire",
+ 	 	 	 	"trans": "Pièces techniques pour les munitions militaires",
  	 	 	 	"eng": "Military ammunition tech parts"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Les pièces de munitions tech de qualité militaire, couramment utilisées par le gouvernement, l'armée et les élites, peuvent être utilisées pour fabriquer des munitions si vous avez le savoir-faire",
+ 	 	 	 	"trans": "Pièces techniques pour des munitions de qualité militaire, couramment utilisées par le gouvernement, l'armée et les élites, peuvent être utilisées pour fabriquer des munitions si vous avez le savoir-faire",
  	 	 	 	"eng": "Military grade ammunition tech parts, commonly used by government, military and the elites,can be used to craft into usable Ammo if you have the know-how"
  	 	 	}
  	 	},


### PR DESCRIPTION
"Ammunition tech parts" means that the parts are technical for the ammunition, not that the ammo is 'tech' because of them, minor mistranslation.