### PR TITLE
Update global_skip.md

### DIFF
--- a/contribution/mobile/en/tutorial/global_skip.md
+++ b/contribution/mobile/en/tutorial/global_skip.md
@@ -8,7 +8,7 @@ To activate Global Skip, players must acquire a premium currency called Units wh
 
 ![GlobalSkip2](/resources/mobile-tutorial/GlobalSkip2.png)
 
-Players can do Global Skip for up to 8 hours AFK task, which costs 2048 Units upon purchase. It is advisable to wait for at least 1 minute before applying Global Skip so that other players can gain the benefit at times.
+Players can do Global Skip for up to 8 hours AFK task, which costs 2048 Units upon purchase. Once purchased, no new skips can be purchased until the skip is completed.
 
 ## Global Skip & Efficiency
 


### PR DESCRIPTION
Nobody waits 1 minute anymore due to the sheer player count. This used to be a thing when the game had... 300 peak players max (100 average) but now the queue time is so long most (probably over 95%) people can immediately go back to their afk tasks and not lose out on any skips.

Added some info just so we don't just have a 1 liner. It feels kinda eh that way.