### PR TITLE
Update tips.txt

### DIFF
--- a/contribution/mobile/en/tips.txt
+++ b/contribution/mobile/en/tips.txt
@@ -121,6 +121,9 @@ You can machine craft more Tech Scraps at the [GANG] via Automatic Recycler.
 If you need BTC, try selling unwanted items to the Weaponsmith.  The "Bargaining" stat helps with this.
 Inventory getting full?  Lost BTC when you flatlined?  Store items or BTC in the [BANK OF ARASAKA].
 POCKETs are increasingly helpful the longer you play as you get more and more items clogging your inventory. Either do a cleanup of those items, or invest in a better backpack when necessary.
+CRIT CHANCE and CRIT damage are sought-after modules as they help speed up the time to complete a dungeon by increasing your DPS.
+BARGAIN is both useful for buying at decreased prices and selling at increased prices at NPC shops. Note: Does not work on the player market.
+STUN and EVADE stack multiplicatively for a 52% chance to not get hit after attacking. (50.4% chance vs an AGILE enemy)
 
 // Experience, Leveling
 Scrap your items to get Tech Scraps, then reverse engineer them to gain printing exp.
@@ -131,16 +134,19 @@ Level up a skill at the [COMMERCIAL AREA] when you have time to spare.
 Study shows that mobs with the "Agile" tag grants more exp.
 Not leveling as fast as you'd like? Try dungeon diving! (You get 2x more exp)
 The gear you get from the [MOLECULAR PRINTER] is always based on your Printing level and not on your overall one, so make sure you always keep your printing level up.
-To keep the game fresh, it's impossible to gain EXP and loot from low level enemies or dungeons after a certain level.
+To keep the game fresh, it's impossible to gain EXP and loot from enemies or dungeons 10 levels below you.
 Fight enemies and dungeons above your level for more juicy exp.
-Wait until someone uses the 180% exp buff to redeem dungeon quest rewards and memory experiences to gain greater experience.
+Wait until someone uses the 180% exp buff to redeem dungeon quest rewards to gain greater experience.
 Doing challenge dungeons with other players is the fastest way to gain levels while having fun!
 Complete quests for a good amount of Bitcoin and exp.
 How to level up faster? Stay away from chat.
 In order to craft a key to unlock the next area, you need to travel to all 3 sub-areas and get the key in each dungeon boss room.
 Is an area locked even though you unlocked it with a key? You may be underleveled.
-It's customary to go clockwise in dungeons.
 Only the first area (level 1-4 area) has no requirements when scavenging. As a complete beginner to the skill, you must start there and gain a few levels first.
+Mining is an absolute pain to level, as it needs quite a hefty sum of money and AFK time. Maybe hold off on it until you reach a point where you have an abundance of BTC/AI.
+Past level 140, no new crafting recipes are unlocked for Medical Science. Just move on to levelling other skills as you need not level it any further by means of AFK.
+Ammo Crafting is a weak skill early on for its cost-inefficient recipes, but once you level it higher it becomes more useful as recipes tend to give more end products.
+When using AI cores, XP and BTC gained is based on your gear score. Make sure to always update your gear with higher level gear for more XP!
 
 // Social, Chat, UI, Systems
 In the chat terminal, you can press [Up Arrow] key to access the last message you send.
@@ -161,15 +167,16 @@ Be nice to other players. :)
 Inventory full? Sell your non-essential items in the player market or to your local trader in chat!
 Being in a gang has the perks of accessing a few new AFK tasks, as well as the gang dungeon. Plus, playing with others just makes the game much better!
 Want to be in a gang? You will have to be invited by someone. There is no application button. 
-If you have a dungeon that you would like to leave, it is good etiquette to post an invite to chat before leaving, so that everyone can hop on by and loot the dungeon.
-Epic caches cost an arm and a leg. If you are at a low level, try selling them thru auction in chat to boost your balance by a significant amount!
+If you have a fully looted dungeon that you would like to leave, it is good etiquette to post an invite to chat before leaving, so that everyone can go and loot the dungeon.
+Epic caches cost an arm and a leg. If you are at a low level and are lucky to get one, try selling them thru auction in chat to boost your balance by a significant amount!
 Since you can't send BTC to players directly, AI Cores and other items replace BTC in direct trades with the gift function. Stock up when buying items from a trader directly.
-Look out for special events like AFK global time skips or calibration boosts in Chat every now and then. You don't want to miss out on these!
+Look out for special events like calibration boosts in Chat every now and then. You don't want to miss out on these!
 Check the player market often to get an idea on the value of your inventory, and if you should buy or sell your items!
 Gear that has a 100% or more chance to break in calibration needs the percentage lowered by using a buff in the Arasaka Unit Exchange. This benefits not only you, but everyone else playing.
 Calibrating gear makes it stronger, but calibrated gear cannot be gifted or sold.
 Each level of calibration on gear adds more to the item than the last level, but is more likely to break the item as well.
 Amadon is an equivalent of Window Shopping! Glaze your eyes onto Players Market while waiting for the AFK task to finish! (buying not included)
+It is highly discouraged to spam in order to complete the chat quest. It only clogs up chat and might just get you muted, leaving you limited access for key functions like trading. 
 
 // Combat, Enemies, Allies
 HP goes back to full after each battle, unless you're in a dungeon!
@@ -177,15 +184,14 @@ You will always recover to full health while not in a dungeon.
 You always attack first, so make good use of that advantage!
 Shields regenerate after you defeat an enemy in the dungeon.
 Craft Pain Away to be able to recover health between fights in dungeons.
-Beware of enemies described as Tough, Angry, Mad, Shielded, Marksman, or Berserker.
-Enemies with descriptors (e.g., Berserker / Mad / Angry) are tougher, but they give better rewards!
+Take note of enemies described as Tough, Angry, Mad, Shielded, Marksman, or Berserker. They are tougher, but give better rewards!
 Secret keys are needed to access higher level stations; search dungeons for their fragments!
 Remember the CCO mantra: Hit, Heal, Hit.
 Challenge dungeons always have a tough boss so don't forget to bring your friends with you when venturing in.
 When you die, you'll lose some of your experience and 10% of your Bitcoins, so be careful!
 Use only primary weapons to overpower street monsters to save ammo.
 You can't enter a dungeon that is 13 levels above your level. It's for your own good.
-If you can survive one hit in a dungeon with a sizable health bar remaining, you can win by keeping yourself healed!
+If you can survive one hit in a dungeon with at least 11% of your HP left, you can win by keeping yourself healed!
 Are you at Death's door in the middle of the treasure room? Ask for support in the chat and direct them to your dungeon!
 Are enemies taking too long to kill? Try increasing your critical chance and critical damage modifier.
 You can enter dungeons already in progress to get quests and loot!
@@ -197,9 +203,11 @@ Tough enemies deal more damage than normal enemies, so have your healing items a
 There's a maximum of 4 enemies in a non-boss dungeon room.
 While challenge dungeons are harder than normal ones, the boss in challenge dungeons gives a ludicrous amount of experience and loot.
 Want to make sure everyone gets loot in a public dungeon? Make sure everyone deals at least 20% of the mob's max HP as damage.
-In public dungeons, everyone can get the loot. No need to worry about stealing loot!
+In public dungeons, everyone can get the loot in the dungeon room. No need to worry about stealing loot!
 Berserker Enemies do not have a tooltip for their buffs. Instead, you can only see it though a really high HP and Shield as well as in the name.
 You can't get any xp or loot from enemies and dungeons 10 levels lower than you. Sorry, but you can't just breeze through and 1 shot every enemy like it's nothing.
+STUN and EVADE stack multiplicatively for a 52% chance to not get hit after attacking. (50.4% chance vs an AGILE enemy)
+Your equipment marks decide your overall mark, dealing or getting dealt extra damage to certain factions of mobs. Try unequipping an item to change your mark and take less damage!
 
 // Misc, Fun, Purchases
 Feeling faint? Stop playing and get some food.
@@ -224,6 +232,7 @@ Remember, CCO mantra is not "Hit, Hit, Die".
 Remember to just enjoy the game and let everyone else do the same!
 If you like CyberCodeOnline, consider suggesting new ideas, dungeon rooms, tips, translations, and more over at the github for the game! You can find it at Profile> Updates.
 There is no pay to win aspect in CyberCodeOnline. Items bought through the Arasaka Unit Exchange benefit everyone, and the Cosmetic Cyberwear is purely cosmetic.
+Cosmetic Cyberwear all cost a recurring amount of real world money, with the exception of Prestige which is a purchase that will stay on your account for a lifetime.
 Want to stop making the same mistakes as a beginner? Play more.
 Want to be more efficient at doing dungeons after doing it for quite some time? Stop doing them and get some rest.
 Looking for the tutorial?  It's in Profile -> Tutorial.


### PR DESCRIPTION
SPEAKING OF OLD TIPS, why not remove those which are simply not true anymore and replace them with new and fresh tips?
Line about looking out for special events: if you miss a skip train nowadays it doesn't hurt since there's a skip train like what, 80-90% of the time? Missing one won't set you back by a lot.
Line "It's customary to go clockwise in dungeons." is no longer relevant. Used to be true back then but nobody does this anymore. It's just chaos. Truthfully people in global are asking why this was even a tip and I just have to tell them that it's outdated.
Line about overlevelling: accuracy of info
Line about 180% exp buff: memory xp doesn't exist now.
Lines about enemies with modifiers: combined because those tips can be useful bundled together for newbies. Knowing they aren't just a nuisance to deal with should surely help them. Seeing the length of some tips this tip is average in length.
Line about loot being private: made it more clear to refer to dungeon rooms (always private loot) rather than mob loot (required minimum 20% of max hp as damage)
Line about living forever if you live with some HP: cleared it up to be 11% specifically. It's a pain 10 doesn't work but what can you do that's how the system works...
Line about dungeon posting on global: clarified to be fully clear since most people who post do fully clear. also I didn't know people didn't always fully clear dungeons back then so that's just on me.
More lines about stats: added
Lines about faction changing gear: added
Lines about skills: added
Line about donations for frames: added
Line about AI: added
Line about chat spam for chat quest: ah yes no chat quest spamming pls a little bit of me dies inside :(
alright this is all my fixing for tips today ig