### PR TITLE
change back "passer" in "skip" for consistency (Trad FR)

### DIFF
--- a/contribution/lang/fr.json
+++ b/contribution/lang/fr.json
@@ -1689,11 +1689,11 @@
  	 	 	 	"vars": [
  	 	 	 	 	"skipCount"
  	 	 	 	],
- 	 	 	 	"trans": "Passer ${skipCount}",
+ 	 	 	 	"trans": "Skipping ${skipCount}",
  	 	 	 	"eng": "Skipping ${skipCount}"
  	 	 	},
  	 	 	"skipAvailable": {
- 	 	 	 	"trans": "Passer disponible",
+ 	 	 	 	"trans": "Skip disponible",
  	 	 	 	"eng": "Skip Available"
  	 	 	}
  	 	},
@@ -2915,7 +2915,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"itemSkipMinutes"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Temps libre passer (${itemSkipMinutes} min)",
+ 	 	 	 	 	"trans": "Time skip gratuit (${itemSkipMinutes} min)",
  	 	 	 	 	"eng": "Free time skip (${itemSkipMinutes} Min)"
  	 	 	 	},
  	 	 	 	"description": {


### PR DESCRIPTION
"Global skip" or "skip" is used in chat and half of the names, and is easier to understand.