### PR TITLE
Update tr.json - Deep fix

### DIFF
--- a/Credits.md
+++ b/Credits.md
@@ -95,6 +95,7 @@ Wanna
 [UGA_UGA](https://github.com/mdendena2000)
 [Mancipi](https://github.com/Mancipi）
 [sugar-choco](https://github.com/sugar-choco)
+[fusiondesu](https://github.com/fusion-desu)
 
 ## Proofreading
 [Skippayy](https://github.com/skippayyyy)

--- a/contribution/lang/tr.json
+++ b/contribution/lang/tr.json
@@ -91,7 +91,7 @@
  	 	 	},
  	 	 	"defaultLines": {
  	 	 	 	"trans": [
- 	 	 	 	 	"Şştt! En iyi ekipmanı burada bulabilirsin hadi ama güven bana."
+ 	 	 	 	 	"Şştt! En iyi ekipmanı burada bulabilirsinin, hadi ama güven bana."
  	 	 	 	],
  	 	 	 	"eng": [
  	 	 	 	 	"You will find the best gear here, trust me."
@@ -100,7 +100,7 @@
  	 	},
  	 	"terminal": {
  	 	 	"name": {
- 	 	 	 	"trans": "terminal",
+ 	 	 	 	"trans": "Terminal",
  	 	 	 	"eng": "Terminal"
  	 	 	},
  	 	 	"tut": {
@@ -1859,7 +1859,7 @@
  	 	},
  	 	"market": {
  	 	 	"lookAround": {
- 	 	 	 	"trans": "Etrafı gezin",
+ 	 	 	 	"trans": "Etrafı gez",
  	 	 	 	"eng": "Look around"
  	 	 	},
  	 	 	"myStall": {
@@ -2426,7 +2426,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"upgradeToSlot"
  	 	 	 	],
- 	 	 	 	"trans": "${upgradeToSlot} slota yükseltin",
+ 	 	 	 	"trans": "${upgradeToSlot} SLOTA YÜKSELT",
  	 	 	 	"eng": "UPGRADE TO ${upgradeToSlot} SLOTS"
  	 	 	},
  	 	 	"takeItemFromVault": {
@@ -3011,13 +3011,13 @@
  	 	 	"attackButton": {
  	 	 	 	"primary": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "birincil",
+ 	 	 	 	 	 	"trans": "Birincil",
  	 	 	 	 	 	"eng": "primary"
  	 	 	 	 	}
  	 	 	 	},
  	 	 	 	"secondary": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "özel",
+ 	 	 	 	 	 	"trans": "Özel",
  	 	 	 	 	 	"eng": "special"
  	 	 	 	 	}
  	 	 	 	},
@@ -3059,7 +3059,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"noHealingPrompt": {
- 	 	 	 	"trans": "Belki önce birkaç can eşyası satın alın?",
+ 	 	 	 	"trans": "Belki önce birkaç can eşyası satın almalısın?",
  	 	 	 	"eng": "Maybe buy some healing item first?",
  	 	 	 	"des": {
  	 	 	 	 	"trans": "Görünüşe göre üzerinde hiç Ağrı Kesicin yok, zindanlara girmeden önce ilk olarak Şehirdeki Trinoky Market'ten bunları satın alabilirsin. Unutma, zindanlarda savaşlardan sonra iyileşmeyeceksin.",
@@ -3274,7 +3274,7 @@
  	 	},
  	 	"tipsBox": {
  	 	 	"title": {
- 	 	 	 	"trans": "Gelişmiş İpuçları",
+ 	 	 	 	"trans": "Profesyonel İpuçları",
  	 	 	 	"eng": "Pro Tips"
  	 	 	},
  	 	 	"description": {
@@ -3496,7 +3496,7 @@
  	 	 	 	"eng": "Health"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Maksimum canı artırır",
+ 	 	 	 	"trans": "Maksimum canı arttırır",
  	 	 	 	"eng": "Increases maximum health"
  	 	 	}
  	 	},
@@ -3506,7 +3506,7 @@
  	 	 	 	"eng": "Armor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Düşmanlardan alınan hasarı axaltır",
+ 	 	 	 	"trans": "Düşmanlardan alınan hasarı azaltır",
  	 	 	 	"eng": "Decreases damage taken from enemies"
  	 	 	}
  	 	},
@@ -3612,7 +3612,7 @@
  	 	 	 	"eng": "Pocket"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Envanter kapasitesini artırır",
+ 	 	 	 	"trans": "Envanter kapasitesini arttırır",
  	 	 	 	"eng": "Increases inventory capacity"
  	 	 	}
  	 	},
@@ -3622,7 +3622,7 @@
  	 	 	 	"eng": "Damage multiplier"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Yüzdeye göre hasarı artırır ",
+ 	 	 	 	"trans": "Yüzdeye göre hasarı arttırır ",
  	 	 	 	"eng": "Increases damage by percentage"
  	 	 	}
  	 	},
@@ -3652,7 +3652,7 @@
  	 	 	 	"eng": "Shield multiplier"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Kalkanın gücünü yüzde oranında artırın ",
+ 	 	 	 	"trans": "Kalkanın gücünü yüzde oranında arttırır ",
  	 	 	 	"eng": "Increase strength of shield by percentage"
  	 	 	}
  	 	},
@@ -3662,7 +3662,7 @@
  	 	 	 	"eng": "Healing multiplier"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "İyileşmenizin gücünü artırın",
+ 	 	 	 	"trans": "İyileşmenizin gücünü arttırır",
  	 	 	 	"eng": "Increases the potency of your heals"
  	 	 	}
  	 	},
@@ -3672,7 +3672,7 @@
  	 	 	 	"eng": "Time reduction"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "AFK görevler için gereken süreyi azaltın",
+ 	 	 	 	"trans": "AFK görevler için gereken süreyi azaltır",
  	 	 	 	"eng": "Reduce AFK task required time"
  	 	 	}
  	 	},
@@ -3682,7 +3682,7 @@
  	 	 	 	"eng": "Exp multiplier"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Kazandığınız EXP'yi artırın",
+ 	 	 	 	"trans": "Kazandığınız EXP'yi arttırır",
  	 	 	 	"eng": "Increase EXP you receive"
  	 	 	}
  	 	},
@@ -3692,7 +3692,7 @@
  	 	 	 	"eng": "BTC multiplier"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Kazandığınız Bitcoinleri artırın",
+ 	 	 	 	"trans": "Kazandığınız Bitcoinleri arttırır",
  	 	 	 	"eng": "Increase Bitcoins you receive"
  	 	 	}
  	 	},
@@ -3734,17 +3734,17 @@
  	 	},
  	 	"rngInterferer": {
  	 	 	"description": {
- 	 	 	 	"trans": "Konteynerlerden ek epik damla şansı",
+ 	 	 	 	"trans": "Konteynerlerden ekstra epik düşürme şansı",
  	 	 	 	"eng": "Additional epic drop chance from containers"
  	 	 	}
  	 	},
  	 	"m1Dmg": {
  	 	 	"name": {
- 	 	 	 	"trans": "Hayvanlar Nemesis",
+ 	 	 	 	"trans": "Animals Nemesis",
  	 	 	 	"eng": "Animals Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Hayvan çetesinin düşmanlarına zarar verir",
+ 	 	 	 	"trans": "Hayvanlar çetesinin düşmanlarına fazladan zarar verir",
  	 	 	 	"eng": "Increases damage to Enemies of Animals gang"
  	 	 	}
  	 	},
@@ -3754,7 +3754,7 @@
  	 	 	 	"eng": "Voodoo Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Voodoo erkek çetesinin düşmanlarına zarar verir",
+ 	 	 	 	"trans": "Voodoo Çocukları çetesinin düşmanlarına fazladan zarar verir",
  	 	 	 	"eng": "Increases damage to Enemies of Voodoo Boys gang"
  	 	 	}
  	 	},
@@ -3764,7 +3764,7 @@
  	 	 	 	"eng": "Scavengers Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Scavengers çetesinin düşmanlarına zarar verir",
+ 	 	 	 	"trans": "Yağmacılar çetesinin düşmanlarına fazladan zarar verir",
  	 	 	 	"eng": "Increases damage to Enemies of Scavengers gang"
  	 	 	}
  	 	},
@@ -3774,7 +3774,7 @@
  	 	 	 	"eng": "Lethal"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Scavengers çetesinin düşmanları size hasar arttırır",
+ 	 	 	 	"trans": "Yağmacılar Çetesi düşmanlarının size verdiği hasar artar",
  	 	 	 	"eng": "Enemies of Scavengers gang deals increased damage to you"
  	 	 	}
  	 	},
@@ -3784,7 +3784,7 @@
  	 	 	 	"eng": "Disruptor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Hayvanların düşmanları çete size hasar arttırır",
+ 	 	 	 	"trans": "Hayvanlar Çetesi düşmanlarının size verdiği hasar artar",
  	 	 	 	"eng": "Enemies of Animals gang deals increased damage to you"
  	 	 	}
  	 	},
@@ -3794,7 +3794,7 @@
  	 	 	 	"eng": "Makeshift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Voodoo Boys Gang'in düşmanları size hasar arttırır",
+ 	 	 	 	"trans": "Voodoo Çocukları Çetesi düşmanlarının size verdiği hasar artar",
  	 	 	 	"eng": "Enemies of Voodoo Boys gang deals increased damage to you"
  	 	 	}
  	 	}
@@ -3858,7 +3858,7 @@
  	 	},
  	 	"backpack3": {
  	 	 	"name": {
- 	 	 	 	"trans": "Explorer'ın sırt çantası",
+ 	 	 	 	"trans": "Gezgin'in sırt çantası",
  	 	 	 	"eng": "Explorer's Backpack"
  	 	 	}
  	 	},
@@ -3909,11 +3909,11 @@
  	 	 	"vars": [
  	 	 	 	"total"
  	 	 	],
- 	 	 	"trans": "Eğer hepsi satılırsa ${total} BitCoin kazanacaksın",
+ 	 	 	"trans": "Eğer hepsi satılırsa ${total} BitCoin kazanacaksınız",
  	 	 	"eng": "If all items are sold, you will earn ${total} BitCoins"
  	 	},
  	 	"sellAmountModalTitle": {
- 	 	 	"trans": "Kaç adet satmak istiyorsun?",
+ 	 	 	"trans": "Kaç adet satmak istersiniz?",
  	 	 	"eng": "How many would you like to sell?"
  	 	},
  	 	"amountSelectModal": {
@@ -3958,7 +3958,7 @@
  	 	},
  	 	"review": {
  	 	 	"title1": {
- 	 	 	 	"trans": "Ben bu oyunun geliştiricisi olan Dexter'im ve deneyiminizi şimdiye kadar tanımayı umuyorum.",
+ 	 	 	 	"trans": "Ben bu oyunun geliştiricisi olan Dexter'im ve deneyiminizi şimdiye kadarki deneyiminizi tanımayı umuyorum.",
  	 	 	 	"eng": "I'm Dexter, the developer of this game, and I hope to know your experience so far."
  	 	 	},
  	 	 	"title2": {
@@ -4023,14 +4023,14 @@
  	 	},
  	 	"resultScreen": {
  	 	 	"title": {
- 	 	 	 	"trans": "Seviye atlamak",
+ 	 	 	 	"trans": "Zafer",
  	 	 	 	"eng": "Victory"
  	 	 	},
  	 	 	"subTitle": {
  	 	 	 	"vars": [
  	 	 	 	 	"levelName"
  	 	 	 	],
- 	 	 	 	"trans": "Tebrik, ${levelName}!",
+ 	 	 	 	"trans": "Tebrikler, ${levelName} yeteneğinin seviyesi yükseldi!",
  	 	 	 	"eng": "Congratulation, you have leveled up your ${levelName}!"
  	 	 	},
  	 	 	"fromTo": {
@@ -4044,12 +4044,12 @@
  	 	},
  	 	"newbieTutorial": {
  	 	 	"welcomeMsg": {
- 	 	 	 	"trans": "En iyi metin mmorpg hoş geldiniz",
+ 	 	 	 	"trans": "En iyi Metne Dayalı MMORPG oyununa hoş geldiniz",
  	 	 	 	"eng": "Welcome to the best Text MMORPG"
  	 	 	},
  	 	 	"noShowToggle": {
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Profile Full Tical'ı görebilirsiniz> Öğretici sekmesi",
+ 	 	 	 	 	"trans": "Profile tüm öğreticiyi görebilirsiniz> Öğretici sekmesi",
  	 	 	 	 	"eng": "You can see the full tutorial at Profile > Tutorial tab"
  	 	 	 	},
  	 	 	 	"label": {
@@ -4066,7 +4066,7 @@
  	 	},
  	 	"chatRuleModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "Lütfen sohbet etmeye başlamadan önce aşağıdaki kuralları kabul edin",
+ 	 	 	 	"trans": "Lütfen sohbet etmeye başlamadan önce aşağıdaki kuralları kabul et",
  	 	 	 	"eng": "Please agree to the rules below before start chatting"
  	 	 	},
  	 	 	"rule1": {
@@ -4086,11 +4086,11 @@
  	 	 	 	"eng": "You will be MUTED if you breach any of the rules"
  	 	 	},
  	 	 	"footer2": {
- 	 	 	 	"trans": "Profilin tam listesi profilde bulunabilir> Öğreticiler> Kurallar",
+ 	 	 	 	"trans": "Kuralların tam listesi profilde bulunabilir> Öğreticiler> Kurallar",
  	 	 	 	"eng": "Full list of rules can be found in Profile > Tutorials > Rules"
  	 	 	},
  	 	 	"disagreeButtonButton": {
- 	 	 	 	"trans": "Numara",
+ 	 	 	 	"trans": "Hayır",
  	 	 	 	"eng": "No"
  	 	 	},
  	 	 	"confirmButton": {
@@ -4103,13 +4103,13 @@
  	 	 	 	 	"eng": "I won't spam"
  	 	 	 	},
  	 	 	 	"notAgree": {
- 	 	 	 	 	"trans": "Kabulmıyorum",
+ 	 	 	 	 	"trans": "Kabul etmiyorum",
  	 	 	 	 	"eng": "I don't agree"
  	 	 	 	}
  	 	 	},
  	 	 	"agreeToggle": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Anlıyorum ve ben hiçbir zaman sohbet kurallarını istemeyeceğim ya da kırmayacağım",
+ 	 	 	 	 	"trans": "Anlıyorum ve ben hiçbir kuralı çiğnemeyeceğim, ve SPAM yapmayacağım",
  	 	 	 	 	"eng": "I understand and I will never spam or break any of the chat rules"
  	 	 	 	}
  	 	 	}
@@ -4132,7 +4132,7 @@
  	 	 	 	"eng": "Send Private Message"
  	 	 	},
  	 	 	"reply": {
- 	 	 	 	"trans": "Cevap vermek",
+ 	 	 	 	"trans": "Cevap ver",
  	 	 	 	"eng": "Reply"
  	 	 	}
  	 	},
@@ -4152,7 +4152,7 @@
  	 	 	 	"eng": "Unofficial translation"
  	 	 	},
  	 	 	"description1": {
- 	 	 	 	"trans": "Bu oyun sadece bir kişi tarafından yapıldığı için, tüm dilleri doğru bir şekilde çevirir, ancak daha fazla çeviri eklemek için çalışıyorum :)",
+ 	 	 	 	"trans": "Bu oyunu tek başıma yaptığımdan, tüm dilleri düzgün şekilde çevirmek oldukça zor, fakat bunun üzerinde çalışıyorum :)",
  	 	 	 	"eng": "As this game is made by only one person, it's very difficult translate all languages correctly, but I am working on adding more translations :)"
  	 	 	},
  	 	 	"description": {
@@ -4171,7 +4171,7 @@
  	 	 	},
  	 	 	"confirmButton": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "anladım",
+ 	 	 	 	 	"trans": "Anladım",
  	 	 	 	 	"eng": "I understand"
  	 	 	 	},
  	 	 	 	"description": {
@@ -4186,7 +4186,7 @@
  	 	 	 	"eng": "An update has been installed"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Lütfen devam etmek için Reload'i tıklayın",
+ 	 	 	 	"trans": "Lütfen devam etmek için yenileyin",
  	 	 	 	"eng": "Please click reload to continue"
  	 	 	},
  	 	 	"reloadButton": {
@@ -4198,7 +4198,7 @@
  	 	},
  	 	"equipmentQuickMenu": {
  	 	 	"unequip": {
- 	 	 	 	"trans": "haksız yere",
+ 	 	 	 	"trans": "Çıkart",
  	 	 	 	"eng": "unequip"
  	 	 	},
  	 	 	"viewDetails": {
@@ -4206,13 +4206,13 @@
  	 	 	 	"eng": "View Details"
  	 	 	},
  	 	 	"swap": {
- 	 	 	 	"trans": "Ekipmanı değiştirin",
+ 	 	 	 	"trans": "Ekipmanı değiştir",
  	 	 	 	"eng": "replace equipment"
  	 	 	}
  	 	},
  	 	"unitDonationConfirm": {
  	 	 	"title": {
- 	 	 	 	"trans": "Bağış onaylamak",
+ 	 	 	 	"trans": "Bağışı onayla",
  	 	 	 	"eng": "Confirm donation"
  	 	 	},
  	 	 	"description": {
@@ -4346,7 +4346,7 @@
  	 	 	"eng": "Calibration Safety Nano Bot"
  	 	},
  	 	"rngInterferer": {
- 	 	 	"trans": "Rng girişim",
+ 	 	 	"trans": "RNG Arayüzü",
  	 	 	"eng": "RNG Interference"
  	 	},
  	 	"flashGrenade": {
@@ -4376,7 +4376,7 @@
  	 	 	"eng": "Click here to scan for street enemies"
  	 	},
  	 	"localCombat": {
- 	 	 	"trans": "Düşmanları yendiğinizde exp, ${currencyName} ve yağmuru alırsınız, \n                 Şimdi bir deneyin!",
+ 	 	 	"trans": "Düşmanları yendiğinizde exp, ${currencyName} ve çeşitli eşyalar alırsınız, \n                 Şimdi bir deneyin!",
  	 	 	"eng": "you will receive exp, ${currencyName} and loots when you defeat enemies,\n                give it a try now!"
  	 	},
  	 	"primaryAttack": {
@@ -4384,15 +4384,15 @@
  	 	 	"eng": "Click here to attack the enemy"
  	 	},
  	 	"statusInv": {
- 	 	 	"trans": "Tüm yağmuru almak için 'Tümünü Al' tıklayın",
+ 	 	 	"trans": "Tüm eşyaları almak için 'Tümünü Al' tıklayın",
  	 	 	"eng": "Click 'TAKE ALL' to get all the loots"
  	 	},
  	 	"dungeonQuest": {
- 	 	 	"trans": "Görevi kabul etmek için 'arayışı kabul et'i tıklayın, istediği zaman görevi tamamlayabilir veya terk edebilirsiniz",
+ 	 	 	"trans": "Görevi kabul etmek için 'kabul et'i tıklayın, istediğiniz zaman görevi tamamlayabilir veya terk edebilirsiniz",
  	 	 	"eng": "Click 'ACCEPT QUEST' to accept the quest, you may complete or abandon the quest at any time"
  	 	},
  	 	"localCombatTip": {
- 	 	 	"trans": "Düşmanları yendiğinizde EXP, Bitcoin ve Sıkıştırıcı alacaksınız, \n                 Şimdi bir deneyin!",
+ 	 	 	"trans": "Düşmanları yendiğinizde EXP, Bitcoin ve Çeşitli Eşyalar alacaksınız, \n                 Şimdi bir deneyin!",
  	 	 	"eng": "you will receive exp, Bitcoin and loots when you defeat enemies,\n                give it a try now!"
  	 	}
  	},
@@ -4403,7 +4403,7 @@
  	 	 	 	"eng": "Most Efficient!"
  	 	 	},
  	 	 	"paypalExclusive": {
- 	 	 	 	"trans": "PayPal Exclusive!",
+ 	 	 	 	"trans": "PayPal'e Özel!",
  	 	 	 	"eng": "PayPal Exclusive!"
  	 	 	}
  	 	},
@@ -4426,14 +4426,14 @@
  	 	 	"eng": "total"
  	 	},
  	 	"receive": {
- 	 	 	"trans": "Almak",
+ 	 	 	"trans": "Al",
  	 	 	"eng": "Receive"
  	 	}
  	},
  	"itemLore": {
  	 	"contribution": {
  	 	 	"title": {
- 	 	 	 	"trans": "Oyuncu Katkıda Bulundu",
+ 	 	 	 	"trans": "Oyuncu tarafından yazılmış içerik",
  	 	 	 	"eng": "Player contributed content"
  	 	 	},
  	 	 	"description": {
@@ -4452,11 +4452,11 @@
  	},
  	"itemStack": {
  	 	"scrap": {
- 	 	 	"trans": "hurda",
+ 	 	 	"trans": "Hurdala",
  	 	 	"eng": "scrap"
  	 	},
  	 	"destroy": {
- 	 	 	"trans": "tahrip etmek",
+ 	 	 	"trans": "Yok et",
  	 	 	"eng": "destroy"
  	 	}
  	},
@@ -4466,16 +4466,16 @@
  	 	 	"eng": "Take all"
  	 	},
  	 	"discard": {
- 	 	 	"trans": "Atmak",
+ 	 	 	"trans": "Envanterden Çıkart",
  	 	 	"eng": "Discard"
  	 	},
  	 	"discardPrompt": {
  	 	 	"title": {
- 	 	 	 	"trans": "Atıklamak istediğinize emin misiniz?",
+ 	 	 	 	"trans": "Eşyayı envanterinden çıkarmak istediğinize emin misiniz?",
  	 	 	 	"eng": "Are you sure you want to discard?"
  	 	 	},
  	 	 	"confirm": {
- 	 	 	 	"trans": "Atmak",
+ 	 	 	 	"trans": "Envanterden Çıkart",
  	 	 	 	"eng": "Discard"
  	 	 	},
  	 	 	"warning": {
@@ -4644,7 +4644,7 @@
  	 	 	 	"likerName",
  	 	 	 	"amount"
  	 	 	],
- 	 	 	"trans": "${likerName} ${amount} adresini gönder",
+ 	 	 	"trans": "${likerName}, AFK atlatman için sana ${amount} gönderdi",
  	 	 	"eng": "${likerName} has send you ${amount} respects for your skip"
  	 	}
  	},
@@ -4656,7 +4656,7 @@
  	 	 	 	 	"eng": "\"Member\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
- 	 	 	 	 	"trans": "Profil resmi kişiselleştirme kilidini aç",
+ 	 	 	 	 	"trans": "Profil resmi kişiselleştirmesinin kilidini aç",
  	 	 	 	 	"eng": "Unlock profile picture customization"
  	 	 	 	},
  	 	 	 	"3": {
@@ -4704,7 +4704,7 @@
  	 	 	 	 	"eng": "Gold Framed Profile (with animation)"
  	 	 	 	},
  	 	 	 	"5": {
- 	 	 	 	 	"trans": "Özel biyo kilidini aç",
+ 	 	 	 	 	"trans": "Özel Biyografinin Kilidini Aç",
  	 	 	 	 	"eng": "Unlock custom bio"
  	 	 	 	},
  	 	 	 	"6": {
@@ -4712,15 +4712,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Gang sloganını özelleştirin",
+ 	 	 	 	 	"trans": "Gang Sloganını Özelleştirin",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Gang İmajını Özelleştirin",
+ 	 	 	 	 	"trans": "Çete Resminizi Özelleştirin",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla",
+ 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla özellik eklenecek",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4744,7 +4744,7 @@
  	 	 	 	 	"eng": "Purple Framed Profile (with animation)"
  	 	 	 	},
  	 	 	 	"5": {
- 	 	 	 	 	"trans": "Özel biyo kilidini aç",
+ 	 	 	 	 	"trans": "Özel Biyografinin Kilidini Aç",
  	 	 	 	 	"eng": "Unlock custom bio"
  	 	 	 	},
  	 	 	 	"6": {
@@ -4752,15 +4752,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Gang sloganını özelleştirin",
+ 	 	 	 	 	"trans": "Gang Sloganını Özelleştirin",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Gang İmajını Özelleştirin",
+ 	 	 	 	 	"trans": "Çete Resminizi Özelleştirin",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla",
+ 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla özellik eklenecek",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4791,26 +4791,26 @@
  	 	 	 	 	"trans": "Patates Çerçeveli Profil (Animasyonlu)",
  	 	 	 	 	"eng": "Potato Framed Profile (with animation)"
  	 	 	 	},
- 	 	 	 	"7": {
- 	 	 	 	 	"trans": "Özel biyo kilidini aç",
+ 	 	 	 	"5": {
+ 	 	 	 	 	"trans": "Özel Biyografinin Kilidini Aç",
  	 	 	 	 	"eng": "Unlock custom bio"
  	 	 	 	},
- 	 	 	 	"8": {
+ 	 	 	 	"6": {
  	 	 	 	 	"trans": "Profilde Barkod Dekorasyonu",
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
- 	 	 	 	"9": {
- 	 	 	 	 	"trans": "Gang sloganını özelleştirin",
+ 	 	 	 	"7": {
+ 	 	 	 	 	"trans": "Gang Sloganını Özelleştirin",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
- 	 	 	 	"10": {
- 	 	 	 	 	"trans": "Gang İmajını Özelleştirin",
+ 	 	 	 	"8": {
+ 	 	 	 	 	"trans": "Çete Resminizi Özelleştirin",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
- 	 	 	 	"11": {
- 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla",
+ 	 	 	 	"9": {
+ 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla özellik eklenecek",
  	 	 	 	 	"eng": "More coming in future update"
- 	 	 	 	},
+ 	 	 	 	}
  	 	 	 	"12": {
  	 	 	 	 	"trans": "Sibernetik bir patates olabileceğinden bahsettim mi?",
  	 	 	 	 	"eng": "Did I mention you could be a Cybernetic Potato?"
@@ -4824,7 +4824,7 @@
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
- 	 	 	 	 	"trans": "Profil resmi kişiselleştirme kilidini aç",
+ 	 	 	 	 	"trans": "Profil Resmi Kişiselleştirmesinin Kilidini Aç",
  	 	 	 	 	"eng": "Unlock profile picture customization"
  	 	 	 	},
  	 	 	 	"3": {
@@ -4836,7 +4836,7 @@
  	 	 	 	 	"eng": "Blue Neon Framed Profile (with animation)"
  	 	 	 	},
  	 	 	 	"5": {
- 	 	 	 	 	"trans": "Özel biyo kilidini aç",
+ 	 	 	 	 	"trans": "Özel Biyografinin Kilidini Aç",
  	 	 	 	 	"eng": "Unlock custom bio"
  	 	 	 	},
  	 	 	 	"6": {
@@ -4844,15 +4844,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Gang sloganını özelleştirin",
+ 	 	 	 	 	"trans": "Gang Sloganını Özelleştirin",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Gang İmajını Özelleştirin",
+ 	 	 	 	 	"trans": "Çete Resminizi Özelleştirin",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla",
+ 	 	 	 	 	"trans": "Gelecekteki güncellemeye daha fazla özellik eklenecek",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4884,7 +4884,7 @@
  	 	 	"eng": "lower armor"
  	 	},
  	 	"boots": {
- 	 	 	"trans": "bot ayakkabı",
+ 	 	 	"trans": "botlar",
  	 	 	"eng": "boots"
  	 	},
  	 	"backpack": {
@@ -4909,16 +4909,16 @@
  	 	 	 	"eng": "I am Dexter, the developer of CyberCode Online."
  	 	 	},
  	 	 	"content3": {
- 	 	 	 	"trans": "Yedek değişikliğiniz varsa, oyunun devamını ve geliştirilmesine devam etmek için bağışlayabilirseniz çok yardımcı olur.",
+ 	 	 	 	"trans": "Eğer biraz fazladan paranız varsa, oyunun devamını ve geliştirilmesine devam etmek için bağışlayabilirseniz çok yardımcı olur.",
  	 	 	 	"eng": "If you have some spare change it would be very helpful if you could donate to help with continued support and development of the game."
  	 	 	},
  	 	 	"content4": {
- 	 	 	 	"trans": "Lütfen rahatsanız bağışlayın, tüm faydalar tüm oyuncular için adil olacaktır ve oyunda bir kenar vermeyecektir.",
+ 	 	 	 	"trans": "Ekonomik açıdan rahatsanız lütfen bağış yapın, tüm faydalar herkes için eşittir ve oynanışa etki etmez.",
  	 	 	 	"eng": "Please only donate if you are comfortable, all benefits are designed to be fair for all players and will not give an edge in gameplay."
  	 	 	}
  	 	},
  	 	"monthlySubscription": {
- 	 	 	"trans": "Aylık abone",
+ 	 	 	"trans": "Aylık Abonelik",
  	 	 	"eng": "Monthly Subscription"
  	 	},
  	 	"benefits": {
@@ -4945,37 +4945,37 @@
  	 	"requirement": {
  	 	 	"damage": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Zarar vermek",
+ 	 	 	 	 	"trans": "Zarar ver",
  	 	 	 	 	"eng": "Deal damage"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Herhangi bir düşmana zarar vermek",
+ 	 	 	 	 	"trans": "Herhangi bir düşmana zarar ver",
  	 	 	 	 	"eng": "Deal damage to any enemy"
  	 	 	 	}
  	 	 	},
  	 	 	"money": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Bitcoins kazanmak",
+ 	 	 	 	 	"trans": "BTC kazan",
  	 	 	 	 	"eng": "Acquire Bitcoins"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Bitcoin'leri herhangi bir şekilde edinir",
+ 	 	 	 	 	"trans": "Bitcoin'leri herhangi bir şekilde edin",
  	 	 	 	 	"eng": "Acquire Bitcoins in any way"
  	 	 	 	}
  	 	 	},
  	 	 	"exp": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Exp almak",
+ 	 	 	 	 	"trans": "Exp topla",
  	 	 	 	 	"eng": "Receive exp"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Herhangi bir kaynaktan EXP almak",
+ 	 	 	 	 	"trans": "Herhangi bir kaynaktan EXP topla",
  	 	 	 	 	"eng": "Receive exp from any source"
  	 	 	 	}
  	 	 	},
  	 	 	"enemyKill": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Düşman öldürmek",
+ 	 	 	 	 	"trans": "Düşman öldür",
  	 	 	 	 	"eng": "Kill enemy"
  	 	 	 	},
  	 	 	 	"description": {
@@ -4985,17 +4985,17 @@
  	 	 	},
  	 	 	"molecularPrint": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Baskı ekipmanları",
+ 	 	 	 	 	"trans": "Ekipman yazdır",
  	 	 	 	 	"eng": "Print equipment"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Herhangi bir madde önbelleğini yazdırmak için moleküler baskı kullanın",
+ 	 	 	 	 	"trans": "Herhangi bir eşyayı yazdırmak için moleküler baskı kullanın",
  	 	 	 	 	"eng": "use molecular print to print any item cache"
  	 	 	 	}
  	 	 	},
  	 	 	"joinDungeon": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Zindanlara katılmak",
+ 	 	 	 	 	"trans": "Zindanlara katıl",
  	 	 	 	 	"eng": "Join Dungeon"
  	 	 	 	},
  	 	 	 	"description": {
@@ -5005,17 +5005,17 @@
  	 	 	},
  	 	 	"clearChallengeDungeon": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Clear Challenge Zindan",
+ 	 	 	 	 	"trans": "Mücadele zindanı temizle",
  	 	 	 	 	"eng": "Clear challenge dungeon"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Bir mücadelenin zindanını temizleyin (kooperatif olabilir)",
+ 	 	 	 	 	"trans": "Bir mücadele zindanını temizleyin (kooperatif olabilir)",
  	 	 	 	 	"eng": "Clear a challenge dungeon (can be co-op)"
  	 	 	 	}
  	 	 	},
  	 	 	"clearDungeon": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Net zindan",
+ 	 	 	 	 	"trans": "Zindanı temizle",
  	 	 	 	 	"eng": "Clear dungeon"
  	 	 	 	},
  	 	 	 	"description": {
@@ -5025,7 +5025,7 @@
  	 	 	},
  	 	 	"clearDungeonCoOp": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Dungeon arkadaşlarınızla temizleyin",
+ 	 	 	 	 	"trans": "Arkadaşlarınla zindan temizle",
  	 	 	 	 	"eng": "Clear dungeon with friends"
  	 	 	 	},
  	 	 	 	"description": {
@@ -5039,27 +5039,27 @@
  	 	 	 	 	"eng": "Use global chat"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Diğer oyuncularla sohbet et, spam izin verilmedi",
+ 	 	 	 	 	"trans": "Diğer oyuncularla sohbet edşn, spam yapmak yasaktır",
  	 	 	 	 	"eng": "Chat with other players, spam not allowed"
  	 	 	 	}
  	 	 	},
  	 	 	"openCrate": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Açık sandık",
+ 	 	 	 	 	"trans": "Sandık Aç",
  	 	 	 	 	"eng": "Open Crate"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Zindanda açık sandık",
+ 	 	 	 	 	"trans": "Zindanda Sandık Aç",
  	 	 	 	 	"eng": "Open crate in dungeon"
  	 	 	 	}
  	 	 	},
  	 	 	"sellItem": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Tüccar olmak",
+ 	 	 	 	 	"trans": "Tüccar ol",
  	 	 	 	 	"eng": "Be a merchant"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Piyasaya bir öğe yerleştirin",
+ 	 	 	 	 	"trans": "Piyasaya bir öğe yerleştir",
  	 	 	 	 	"eng": "Place an item on the market"
  	 	 	 	}
  	 	 	}
@@ -5087,7 +5087,7 @@
  	 	 	 	 	"amount",
  	 	 	 	 	"itemName"
  	 	 	 	],
- 	 	 	 	"trans": "${amount} ${itemName} satın almak",
+ 	 	 	 	"trans": "${amount} ${itemName} satın alınacak",
  	 	 	 	"eng": "Buying ${amount} of ${itemName}"
  	 	 	},
  	 	 	"priceDisplay": {
@@ -5102,7 +5102,7 @@
  	},
  	"itemTrait": {
  	 	"stun": {
- 	 	 	"trans": "çarpıcı",
+ 	 	 	"trans": "sersemletme",
  	 	 	"eng": "of Stunning"
  	 	},
  	 	"bargain": {
@@ -5114,39 +5114,39 @@
  	 	 	"eng": "of Power"
  	 	},
  	 	"health": {
- 	 	 	"trans": "sağlığın",
+ 	 	 	"trans": "sağlık",
  	 	 	"eng": "of Health"
  	 	},
  	 	"healthRegen": {
- 	 	 	"trans": "hayatın",
+ 	 	 	"trans": "yaşam",
  	 	 	"eng": "of Life"
  	 	},
  	 	"maxShield": {
- 	 	 	"trans": "koruma",
+ 	 	 	"trans": "kalkan",
  	 	 	"eng": "of Shielding"
  	 	},
  	 	"sneaky": {
- 	 	 	"trans": "gizlice",
+ 	 	 	"trans": "gizlilik",
  	 	 	"eng": "of Sneaking"
  	 	},
  	 	"evade": {
- 	 	 	"trans": "kaçak",
+ 	 	 	"trans": "kaçma",
  	 	 	"eng": "of Evasion"
  	 	},
  	 	"pocketed": {
- 	 	 	"trans": "cepler ile",
+ 	 	 	"trans": "cepler",
  	 	 	"eng": "with pockets"
  	 	},
  	 	"criticalChanceArmor": {
- 	 	 	"trans": "kriter şansı",
+ 	 	 	"trans": "kritik şansı",
  	 	 	"eng": "of Crit Chance"
  	 	},
  	 	"criticalChanceWeapon": {
- 	 	 	"trans": "kriter şansı",
+ 	 	 	"trans": "kritik şansı",
  	 	 	"eng": "of Crit Chance"
  	 	},
  	 	"criticalDamageArmor": {
- 	 	 	"trans": "kriter hasarı",
+ 	 	 	"trans": "vahşilik",
  	 	 	"eng": "of Brutality"
  	 	},
  	 	"healingMultiplier": {
@@ -5154,11 +5154,11 @@
  	 	 	"eng": "of Healing"
  	 	},
  	 	"criticalDamageWeapon": {
- 	 	 	"trans": "kriter hasarı",
+ 	 	 	"trans": "kritik hasar",
  	 	 	"eng": "of Crit Damage"
  	 	},
  	 	"upgradeHealth": {
- 	 	 	"trans": "sağlığın",
+ 	 	 	"trans": "sağlık",
  	 	 	"eng": "of Health"
  	 	},
  	 	"upgradeDamage": {
@@ -5170,31 +5170,31 @@
  	 	 	"eng": "of Shield"
  	 	},
  	 	"upgradeSneaky": {
- 	 	 	"trans": "gizlice",
+ 	 	 	"trans": "gizlilik",
  	 	 	"eng": "of Sneaking"
  	 	},
  	 	"upgradeHealthRegen": {
- 	 	 	"trans": "hayatın",
+ 	 	 	"trans": "yaşam",
  	 	 	"eng": "of Life"
  	 	},
  	 	"upgradeStun": {
- 	 	 	"trans": "stun",
+ 	 	 	"trans": "sersemletme",
  	 	 	"eng": "of Stun"
  	 	},
  	 	"upgradeCriticalChance": {
- 	 	 	"trans": "kriter şansı",
+ 	 	 	"trans": "kritik şansı",
  	 	 	"eng": "of Crit Chance"
  	 	},
  	 	"upgradeCriticalDamage": {
- 	 	 	"trans": "kriter hasarı",
+ 	 	 	"trans": "kritik hasar",
  	 	 	"eng": "of Crit Damage"
  	 	},
  	 	"upgradeEvade": {
- 	 	 	"trans": "kaçmak",
+ 	 	 	"trans": "kaçış",
  	 	 	"eng": "of Evade"
  	 	},
  	 	"upgradePocketed": {
- 	 	 	"trans": "genişleme",
+ 	 	 	"trans": "genişletme",
  	 	 	"eng": "of Expansion"
  	 	}
  	},
@@ -5230,17 +5230,17 @@
  	 	}
  	},
  	"misc,durability": {
- 	 	"trans": "dayanıklılık",
+ 	 	"trans": "Dayanıklılık",
  	 	"eng": "durability"
  	},
  	"equipmentMarks": {
  	 	"mark1": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Lethal",
+ 	 	 	 	"trans": "Ölümcül",
  	 	 	 	"eng": "Lethal"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Anlaşmalar hayvan çetesine zarar verdi. Scavengers çetesinden artan hasar alır.",
+ 	 	 	 	"trans": "Anlaşmalar Hayvanlar çetesine zarar verdi. Yağmacılar çetesinden artan hasar alır.",
  	 	 	 	"eng": "deals increased damage to Animals gang. receives increased damage from Scavengers gang."
  	 	 	}
  	 	},
@@ -5250,17 +5250,17 @@
  	 	 	 	"eng": "Disruptor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Fırsatlar Voodoo Boys Gang'e zarar verdi. hayvanlar çetesinden artan hasar alır.",
+ 	 	 	 	"trans": "Anlaşmalar Voodoo Çocukları çetesine çetesine zarar verdi. Hayvanlar çetesinden artan hasar alır.",
  	 	 	 	"eng": "deals increased damage to Voodoo Boys gang. receives increased damage from Animals gang."
  	 	 	}
  	 	},
  	 	"mark3": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Geçici",
+ 	 	 	 	"trans": "El Yapımı",
  	 	 	 	"eng": "Makeshift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Scavengers çetesine hasar arttırır. Voodoo Boys Gang'den artan hasar alır.",
+ 	 	 	 	"trans": "Anlaşmalar Yağmacılar çetesine çetesine zarar verdi. Voodoo Çocukları çetesinden artan hasar alır.",
  	 	 	 	"eng": "deals increased damage to Scavengers gang. receives increased damage from Voodoo Boys gang."
  	 	 	}
  	 	}
@@ -5274,13 +5274,13 @@
  	 	},
  	 	"gang2": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Voodoo çocuklar",
+ 	 	 	 	"trans": "Voodoo Çocukları",
  	 	 	 	"eng": "Voodoo boys"
  	 	 	}
  	 	},
  	 	"gang3": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Çöpçü",
+ 	 	 	 	"trans": "Yağmacılar",
  	 	 	 	"eng": "Scavengers"
  	 	 	}
  	 	}
@@ -5303,7 +5303,7 @@
  	 	 	"eng": "Legendary"
  	 	},
  	 	"donation5": {
- 	 	 	"trans": "Sibernetik patates",
+ 	 	 	"trans": "Sibernetik Patates",
  	 	 	"eng": "Cybernetic Potato"
  	 	},
  	 	"donation6": {


### PR DESCRIPTION
Many people on Turkish server doesn't use "Turkish" just because of bad translation. I've fixed many of those bad translations. Please let me now If my translation gets approved...

Fixed;

- Review screen
- Inventory screen
- Rules
- Store
- Subscriptions
- Battle Screen
- Upgrading Screen and Upgrading Items
- Moderating log texts
- Dungeon Screens
- AFK Skip log texts
- Some spelling errors
- Idk who but looks like somebody was trolling turkish translation, I fixed them too ("Ok" as "Yes" was translated by "Arrow" for example)