### PR TITLE
fixed zh-CN trans on abortWarning

### DIFF
--- a/contribution/lang/zh-CN.json
+++ b/contribution/lang/zh-CN.json
@@ -2962,7 +2962,7 @@
  	 	 	 	"eng": "The task will continue even if you close the game"
  	 	 	},
  	 	 	"abortWarning": {
- 	 	 	 	"trans": "终止这个任务您将不会收到任何奖励，并返回所使用的材料",
+ 	 	 	 	"trans": "终止这个任务您将不会收到任何奖励，且不会返回所使用的材料",
  	 	 	 	"eng": "By aborting this you won\\'t receive any reward and the material used won\\'t be returned"
  	 	 	},
  	 	 	"marketShortcut": {


### PR DESCRIPTION
fixed zh-CN trans on abortWarning, previous versions mean that the material will be returned by aborting