### PR TITLE
Update tips.txt

### DIFF
--- a/contribution/mobile/en/tips.txt
+++ b/contribution/mobile/en/tips.txt
@@ -4,7 +4,7 @@
 Scrap your items to get Tech Scraps; reverse engineer them to gain PRINTING experience.
 You can sell your items in the [PLAYER MARKET].
 Your crafting ranks cannot exceed your overall LEVEL; don't waste time doing research when you're capped.
-HP regenerates 100% after each battle unless you're in a dungeon!
+HP regenerates to full after each battle unless you're in a dungeon!
 You always attack first; use it to your advantage!
 You can repair your damaged equipped gear at the [WEAPON SMITH].
 Your inventory has a storage limit; keep an eye on it or you will lose loot.
@@ -72,10 +72,10 @@ You need a lot of Tech Scraps to open a locked container.
 Scrap your unused items to get Tech Scraps; you will need them to open locked containers.
 Ask your friendly neighbor for prices of assorted items!
 It's recommended to redeem dungeon quest rewards and memory experiences with the 180% xp buff. You'll gain almost double EXP!
-After early game, Pain Aways become virtually useless, so feel free to recycle them for ~50% chance of a Medical Tech Part per Pain Away.
+After early game, Pain Aways become virtually useless to heal with, so feel free to recycle them for ~50% chance of a Medical Tech Part per Pain Away.
 Are you at Death's door in the middle of the treasure room? Ask for support in the chat and direct them to your dungeon.
 An unprepared dungeon explorer is a dead dungeon explorer.
-If you can't afford to print a rare item cache, try checking out the [PLAYER MARKET] first and seek cheaper alternatives. You might find affordable items for your level.
+If you can't afford to print a certain quality of item cache, try checking out the [PLAYER MARKET] first and seek cheaper alternatives. You might find affordable items for your level.
 Inventory management is crucial.
 If you can survive one hit in a dungeon with at least 11% HP remaining, you can win by keeping yourself healed!
 You can switch equipment during a dungeon.
@@ -104,7 +104,7 @@ Are your healing items healing for half of your max HP or less? Consider transit
 Tough enemies deal more damage than normal enemies, so have your healing items at the ready.
 There's a maximum of 4 enemies in a non-boss dungeon room.
 While challenge dungeons take longer than normal ones and are harder, the boss in challenge dungeons gives a ludicrous amount of experience and loot.  
-Epic caches cost an arm and a leg. If you are at a low level, try selling them thru auction in chat to boost your balance by a significant amount!
+Epic caches cost an arm and a leg. If you are lucky enough to get one at a low level, try selling them thru auction in chat to boost your balance by a significant amount!
 Since you can't send BTC to players directly, AI Cores or other items can replace BTC in direct trades with the gift function. Stock up when buying items from a trader directly.
 Want to make sure everyone gets loot in a public dungeon? Make sure everyone deals at least 20% of the mob's max HP as damage.
 In public dungeons, all loot is available to players inside. No need to worry about stealing loot!
@@ -120,7 +120,7 @@ You can machine craft more Tech Scraps at the [GANG] via Automatic Recycler.
 If you need BTC, try selling unwanted items to the Weaponsmith.  The "Bargaining" stat helps with this.
 Inventory getting full?  Lost BTC when you flatlined?  Store items or BTC in the [BANK OF ARASAKA].
 POCKETs are increasingly helpful the longer you play as you get more and more items clogging your inventory. Either do a cleanup of those items, or invest in a better backpack when necessary.
-CRIT CHANCE and CRIT damage are sought-after modules as they help speed up the time to complete a dungeon by increasing your DPS.
+CRIT CHANCE and CRIT DAMAGE are sought-after modules as they help speed up the time to complete a dungeon by increasing your DPS.
 BARGAIN is both useful for buying at decreased prices and selling at increased prices at NPC shops. Note: Does not work on the player market.
 STUN and EVADE stack multiplicatively for a 52% chance to not get hit after attacking. (50.4% chance vs an AGILE enemy)
 
@@ -131,7 +131,7 @@ You can reverse engineer scraps at [JOB HUB] to gain printing exp.
 "Trash" quality equipments are useful for getting tech scraps and printing exp.
 Level up a skill at the [COMMERCIAL AREA] when you have time to spare.
 Study shows that mobs with the "Agile" tag grants more exp.
-Not leveling as fast as you'd like? Try dungeon diving! (You get 2x more exp)
+Not leveling as fast as you'd like? Try dungeon diving! (You get 2x more exp, 2.3x for gang dungeons)
 The gear you get from the [MOLECULAR PRINTER] is always based on your Printing level and not on your overall one, so make sure you always keep your printing level up.
 To keep the game fresh, it's impossible to gain EXP and loot from enemies or dungeons 10 levels below you.
 Fight enemies and dungeons above your level for more juicy exp.
@@ -143,11 +143,15 @@ In order to craft a key to unlock the next area, you need to travel to all 3 sub
 Is an area locked even though you unlocked it with a key? You may be underleveled.
 Only the first area (level 1-4 area) has no requirements when scavenging. As a complete beginner to the skill, you must start there and gain a few levels first.
 Mining is an absolute pain to level, as it needs quite a hefty sum of money and AFK time. Maybe hold off on it until you reach a point where you have an abundance of BTC/AI/Hashes.
+When levelling mining below level 200, it is best to wait for a 100% BTC boost and 80% Synapse to minimize BTC losses from hash mining and maximize XP gained in that short timespan.
 Past level 140, no new crafting recipes are unlocked for Medical Science. Just move on to levelling other skills as you need not level it any further by means of AFK.
-Ammo Crafting is a weak skill early on for its cost-inefficient recipes, but once you level it higher it becomes more useful as recipes tend to give more end products.
+Ammo Crafting is not as useful early on as it is cost-inefficient, but later on it becomes more useful as more ammo is crafted, notably antimatter charges to start using destructive weapons consistently.
+Sometimes it is best to strategically hold off from levelling printing level as to be able to make upgrade modules for your lowest level gear.
 When using AI cores, XP and BTC gained is based on your gear score. Make sure to always update your gear with higher level gear for more XP!
 Did someone pop a frontal cortex enhancement? Use the extra xp to grind dungeons. A synpatic accelerator? Maybe do some AFK tasks at a faster speed.
-Want to make money quick? Try scavenging for some med tech and then recycle it at a gang recycler for tech scrap, and then sell it! This also gives you scavenging XP.
+Want to make money quick? With a synpatic accelerator up, scavenge for med tech and recycle at a gang recycler for tech scrap to sell. This also helps level scavenging up for better med tech rates.
+What's the simplest way to level faster? Don't die. Consistency is better than speed. Take your time to avoid any deaths before you find a rhythm that works for you, and then work on speed.
+Early on dungeons and AI farming are about equal in efficiency. AI farming is death free, not as hands-on, but consumes a lot of money. Decide if you would rather choose money or automation.
 
 // Social, Chat, UI, Systems
 In the chat terminal, you can press [Up Arrow] key to access the last message you send.
@@ -169,27 +173,30 @@ Inventory full? Sell your non-essential items in the player market or to your lo
 Being in a gang has the perks of accessing a few new AFK tasks, as well as the gang dungeon. Plus, playing with others just makes the game much better!
 Want to be in a gang? You will have to be invited by someone. There is no application button. 
 If you have a fully looted dungeon that you would like to leave, it is good etiquette to post an invite to chat before leaving, so that everyone can go and loot the dungeon.
-Epic caches cost an arm and a leg. If you are at a low level and are lucky to get one, try selling them thru auction in chat to boost your balance by a significant amount!
+Epic caches cost an arm and a leg. If you are lucky enough to get one at a low level, try selling them thru auction in chat to boost your balance by a significant amount!
 Since you can't send BTC to players directly, AI Cores and other items replace BTC in direct trades with the gift function. Stock up when buying items from a trader directly.
 Look out for special events like calibration boosts in Chat every now and then. You don't want to miss out on these!
 Check the player market often to get an idea on the value of your inventory, and if you should buy or sell your items!
-Gear that has a 100% or more chance to break in calibration needs the percentage lowered by using a buff in the Arasaka Unit Exchange. This benefits not only you, but everyone else playing.
-Calibrating gear makes it stronger, but calibrated gear cannot be gifted or sold.
+Gear that have at least 100% chance to break in calibration can be lowered using a global buff in the Unit Exchange. Alteratively, rare locked containers have a variation that only affects you.
+Calibrating gear makes it stronger, but calibrated gear cannot be gifted or sold until it is factory reset, making it tradebale again but losing its calibration.
 Each level of calibration on gear adds more to the item than the last level, but is more likely to break the item as well.
 Amadon is an equivalent of Window Shopping! Glaze your eyes onto Players Market while waiting for the AFK task to finish! (buying not included)
 It is highly discouraged to spam in order to complete the chat quest. It only clogs up chat and might just get you muted, temporarily or permanently barring access for key functions like trading. 
+Always be wary of people attempting to rip you off on your item by underpricing it. Remember to always check other offers first and choose the best one according to your own judgement and situation.
+It is fine to talk about real world events in global, but keep in mind to respect people's opinions despite yours differing and to avoid vulgarity as CyberCodeOnline is an all ages community.
 
 // Combat, Enemies, Allies
 HP goes back to full after each battle, unless you're in a dungeon!
 You will always recover to full health while not in a dungeon.
 You always attack first, so make good use of that advantage!
 Shields regenerate after you defeat an enemy in the dungeon.
-Craft Pain Away to be able to recover health between fights in dungeons.
-Take note of enemies described as Tough, Angry, Mad, Shielded, Marksman, or Berserker. They are tougher, but give better rewards!
+Craft or buy Pain Away to be able to recover health between fights in dungeons.
+Take note of enemies described as Tough, Angry, Mad, Agile, Shielded, Marksman, or Berserker. They are tougher, but give better rewards!
 Secret keys are needed to access higher level stations; search dungeons for their fragments!
 Remember the CCO mantra: Hit, Heal, Hit.
 Challenge dungeons always have a tough boss so don't forget to bring your friends with you when venturing in.
-When you die, you'll lose some of your experience and 10% of your Bitcoins, so be careful!
+When you die, you'll lose 10% of the total experience to go to the next level and 10% of your Bitcoins on hand, so be careful! 
+If you die with under 10% of the progress to the next level, you will go down a level. Be careful to not die!
 Use only primary weapons to overpower street monsters to save ammo.
 You can't enter a dungeon that is 13 levels above your level. It's for your own good.
 If you can survive one hit in a dungeon with at least 11% of your HP left, you can win by keeping yourself healed!
@@ -210,6 +217,7 @@ Berserker Enemies do not have a tooltip for their buffs. Instead, you can only s
 You can't get any xp or loot from enemies 3 gear levels and dungeons 10 levels lower than you. Sorry, but you can't just breeze through and 1 shot every enemy like it's nothing.
 STUN and EVADE stack multiplicatively for a 52% chance to not get hit after attacking. (50.4% chance vs an AGILE enemy)
 Your equipment marks decide your overall mark, dealing or getting dealt extra damage to certain factions of mobs. Try unequipping an item to change your mark and take less damage!
+Preparing a burst of dungeon grinding? Try saving up quests which give buffs and use them all at once to do dungeons faster and consume less medicine.
 
 // Misc, Fun, Purchases
 Feeling faint? Stop playing and get some food.


### PR DESCRIPTION
Changed lines:
line 7: the wording was kinda gramatically broken: "HP regenerates (to?) 100% every battle"-> "HP regenerates to full every battle"
line 75: virtually useless for healing*, it kinda just said "oh it's basically useless, so here's a use (it's not useless!)"
line 78: it made it look like this is specifically for rare (yellow) caches only.
line 107: I got bugged by a random person in chat about this before, and they're not wrong lol ofc you need to get an ebic first. Sure that's a given, but I kinda forgor to state that you have to get lucky first 💀. Literally trolling
line 123: inconsistent capitalization
line 134: gang dungeons moment
line 147: added note about destructive weapons and AMC
line 150 (152 in new ver): I have to mention a synaptic has to be up because I forgor 💀 to add it when I made this lol. Made the second sentence more on level up than a "well duh" kind of thing because yes.
line 176 (180 new ver): technically not true because RLC YEP
line 177 (181 new ver): mentioned factory reset shards
line 187 (193 new ver): gotta give the newbs options
line 188 (194 new ver): come on did we really miss agile :/
line 194 (198 new ver): made it more clear what %, and that only BTC on hand is lost (not in bank!)

Added lines: 
line 146: As much as it breaks the exactly 1 skill tip per skill from 144-149, this has to be stated because imagine randomly spending 5K btc/hash xp drops when you can spend 3K btc/hash xp drop for example lol rip money. And yes that money reduces the time it takes before mining breaks even so it's good to know.
line 149: I should add this printing tip. It's not really asuseful early on but 1) I'd rather let people know and 2) lines 144-149 (and to some extent 150) are supposed to be tips on skills (namely about levelling skills) and full penta skill tips (and main level if you include 150) kinda poggers tho.
line 153: As much as I meme on global "just don't die lol!!!1one" it's true. Like literally just don't die, get consistent, and then get fast.
line 154: AI farm vs dungeon early game talk
line 185: look i'm sorry flippers but I have to mention this. It's not exactly "rip off" when it's like 5% but in CCO 5% is a lot of % lol *shrugs*
line 186: cyberchatonline (me when the f bomb s bomb and the real bomb, OH SHOOT EVACUATE EVERYONE IT IS NOT SAFE HERE)
line 199: works in tandem with line 198
line 220: surprised this isn't a tip. like literally this is just free xp and free med savings (except for people who already ohko everything except the boss but still med savings on the boss from tough 1-5 and overcharged 1-5? It's still 75% str and 75% def, unless it's muliplicative ._., but either way med savings from boss like at endgame it still costs 32 meds to heal/turn= approx. 2 ai and at 5 trips you only need to save approx. 3 turns of healing/boss from 75% def and 75% str.)

line amogus: lost to susiety (we live in it)
line 250: it barely exists by A SINGLE LINE pogger 300 lines when

anyway that's all the edits i'm making tips is getting too heavy man i can't carry this much while speedrunning sleep deprivation (jk about the sleep deprivation but like this is a lot of changes so I should REALLY stop)