### PR TITLE
Updated german commen used curse words

### DIFF
--- a/contribution/lang/de.json
+++ b/contribution/lang/de.json
@@ -5,11 +5,11 @@
  	 	 	"eng": "Inventory"
  	 	},
  	 	"quest": {
- 	 	 	"trans": "Suche",
+ 	 	 	"trans": "Aufträge",
  	 	 	"eng": "Quest"
  	 	},
  	 	"chat": {
- 	 	 	"trans": "Plaudern",
+ 	 	 	"trans": "Kommunikation",
  	 	 	"eng": "Chat"
  	 	},
  	 	"profile": {
@@ -46,7 +46,7 @@
  	 	},
  	 	"cosmetic": {
  	 	 	"name": {
- 	 	 	 	"trans": "Kosmetischer Cyberwear",
+ 	 	 	 	"trans": "Kosmetische Cyberwear",
  	 	 	 	"eng": "Cosmetic Cyberwear"
  	 	 	},
  	 	 	"tut": {
@@ -535,19 +535,19 @@
  	 	},
  	 	"upperArmor": {
  	 	 	"name": {
- 	 	 	 	"trans": "Rüstung (Torso)",
+ 	 	 	 	"trans": "Jacke",
  	 	 	 	"eng": "upper armor"
  	 	 	}
  	 	},
  	 	"lowerArmor": {
  	 	 	"name": {
- 	 	 	 	"trans": "Rüstung (Beine)",
+ 	 	 	 	"trans": "Hose",
  	 	 	 	"eng": "lower armor"
  	 	 	}
  	 	},
  	 	"boots": {
  	 	 	"name": {
- 	 	 	 	"trans": "Stiefel",
+ 	 	 	 	"trans": "Schuhe",
  	 	 	 	"eng": "boots"
  	 	 	}
  	 	},
@@ -1370,7 +1370,7 @@
  	 	},
  	 	"gambling1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Spiele das MEGA Pachinko Spiel",
+ 	 	 	 	"trans": "Spiele MEGA Pachinko",
  	 	 	 	"eng": "Play MEGA Pachinko Game"
  	 	 	},
  	 	 	"description": {
@@ -1799,7 +1799,7 @@
  	 	 	 	"eng": "system link"
  	 	 	},
  	 	 	"streetCred": {
- 	 	 	 	"trans": "Straße glaubt",
+ 	 	 	 	"trans": "Straßen Glaube",
  	 	 	 	"eng": "Street Cred"
  	 	 	},
  	 	 	"status": {
@@ -1854,7 +1854,7 @@
  	 	 	 	 	"eng": "Remove from Friend List"
  	 	 	 	},
  	 	 	 	"giveStreetCred": {
- 	 	 	 	 	"trans": "Street Cred geben",
+ 	 	 	 	 	"trans": "Straßen Glaube geben",
  	 	 	 	 	"eng": "Give Street Cred"
  	 	 	 	}
  	 	 	},
@@ -2293,7 +2293,7 @@
  	 	 	 	"eng": "All Apps"
  	 	 	},
  	 	 	"tutorial": {
- 	 	 	 	"trans": "Lernprogramm",
+ 	 	 	 	"trans": "Spielanleitung",
  	 	 	 	"eng": "Tutorial"
  	 	 	}
  	 	},

--- a/contribution/word-filter.json
+++ b/contribution/word-filter.json
@@ -199,5 +199,16 @@
 		"masturbar",
 		"masturbação",
 		"masturba"
+		"Arschfresse"
+		"Arschlecker"
+		"Arschficker"
+		"Pimmel"
+		"Schwanzlutscher"
+		"Kanacke"
+		"Fettsack"
+		"Schlampe"
+		"Mutterficker"
+		"Assi"
+		"Aushilfsnazi"
 	]
 }

--- a/contribution/word-filter.json
+++ b/contribution/word-filter.json
@@ -198,17 +198,17 @@
 		"puta",
 		"masturbar",
 		"masturbação",
-		"masturba"
-		"Arschfresse"
-		"Arschlecker"
-		"Arschficker"
-		"Pimmel"
-		"Schwanzlutscher"
-		"Kanacke"
-		"Fettsack"
-		"Schlampe"
-		"Mutterficker"
-		"Assi"
+		"masturba",
+		"Arschfresse",
+		"Arschlecker",
+		"Arschficker",
+		"Pimmel",
+		"Schwanzlutscher",
+		"Kanacke",
+		"Fettsack",
+		"Schlampe",
+		"Mutterficker",
+		"Assi",
 		"Aushilfsnazi"
 	]
 }


### PR DESCRIPTION
Translations
		"Arschfresse" - Analface
		"Arschlecker" - Anallicker
		"Arschficker" - Analfucker
		"Pimmel" - other word for dick
		"Schwanzlutscher" - dicksucker
		"Kanacke" - curse word for imigrants
		"Fettsack" - "Fat guy"
		"Schlampe" - "Bitch"
		"Mutterficker" - "Motherfucker"
		"Assi" - curse word for jobless
		"Aushilfsnazi" - nazi thing