### PR TITLE
Update Part 2 for German lang quality

### DIFF
--- a/contribution/lang/de.json
+++ b/contribution/lang/de.json
@@ -2433,7 +2433,7 @@
  	 	 	},
  	 	 	"preventDestructionButton": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Verhinderung der Zerstörung",
+ 	 	 	 	 	"trans": "Verhindern der Zerstörung",
  	 	 	 	 	"eng": "Prevent Destruction"
  	 	 	 	}
  	 	 	},
@@ -3085,7 +3085,7 @@
  	 	"quest": {
  	 	 	"globalQuest": {
  	 	 	 	"progressTitle": {
- 	 	 	 	 	"trans": "SL-Rechenzentrum Datenklau",
+ 	 	 	 	 	"trans": "SL-Rechenzentrum Daten Diebstahl",
  	 	 	 	 	"eng": "SL-Data Fortress Breach"
  	 	 	 	},
  	 	 	 	"infoBox": {
@@ -3162,7 +3162,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"noHealingPrompt": {
- 	 	 	 	"trans": "Ohne Heil-Items Fortfahren?",
+ 	 	 	 	"trans": "Ohne Heilungs-Items Fortfahren?",
  	 	 	 	"eng": "Maybe buy some healing item first?",
  	 	 	 	"des": {
  	 	 	 	 	"trans": "Es scheint, als hättest du kein Pain-Away™ dabei. Kauf dir beim Trinoky Mart in der Stadt etwas Pain-Away™, bevor du einen Dungeon betritst, da du nicht Regenerierst",
@@ -3515,7 +3515,7 @@
  	 	"rangeSelector": {
  	 	 	"selectMinValue": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Wählen Sie den min-Wert aus",
+ 	 	 	 	 	"trans": "Wählen Sie den minindest Wert aus",
  	 	 	 	 	"eng": "Select min value"
  	 	 	 	}
  	 	 	},
@@ -3551,14 +3551,14 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"playerName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Deblock ${playerName}",
+ 	 	 	 	 	"trans": "entblockieren ${playerName}",
  	 	 	 	 	"eng": "Unblock ${playerName}"
  	 	 	 	}
  	 	 	}
  	 	},
  	 	"npcSellPage": {
  	 	 	"autoSell": {
- 	 	 	 	"trans": "Autoverkauf",
+ 	 	 	 	"trans": "Automatischer verkauf",
  	 	 	 	"eng": "Auto Sell"
  	 	 	}
  	 	}
@@ -3573,7 +3573,7 @@
  	 	 	"eng": "Name"
  	 	},
  	 	"tag": {
- 	 	 	"trans": "Schild",
+ 	 	 	"trans": "Kürzel",
  	 	 	"eng": "Tag"
  	 	},
  	 	"donate": {
@@ -3683,7 +3683,7 @@
  	 	 	}
  	 	},
  	 	"escape": {
- 	 	 	"trans": "Flieh",
+ 	 	 	"trans": "Flucht",
  	 	 	"eng": "escape"
  	 	},
  	 	"equipped": {
@@ -3802,7 +3802,7 @@
  	 	},
  	 	"escape": {
  	 	 	"name": {
- 	 	 	 	"trans": "Flieh",
+ 	 	 	 	"trans": "Flucht",
  	 	 	 	"eng": "Escape"
  	 	 	},
  	 	 	"description": {
@@ -3978,7 +3978,7 @@
  	 	 	 	"eng": "Animals Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Erhöht den Schaden an Feinden von Tierenbanden",
+ 	 	 	 	"trans": "Erhöht den Schaden an Feinden von Tierenanden",
  	 	 	 	"eng": "Increases damage to Enemies of Animals gang"
  	 	 	}
  	 	},
@@ -3994,11 +3994,11 @@
  	 	},
  	 	"m3Dmg": {
  	 	 	"name": {
- 	 	 	 	"trans": "Scavengers-Nemesis",
+ 	 	 	 	"trans": "Aasgeier-Nemesis",
  	 	 	 	"eng": "Scavengers Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Erhöht den Schaden an Feinden der Scavengers-Gang",
+ 	 	 	 	"trans": "Erhöht den Schaden an Feinden der Aasgeier-Gang",
  	 	 	 	"eng": "Increases damage to Enemies of Scavengers gang"
  	 	 	}
  	 	},
@@ -4008,7 +4008,7 @@
  	 	 	 	"eng": "Lethal"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Feinde der Facavenger-Gang verursachen mehr Schaden",
+ 	 	 	 	"trans": "Feinde der Aasgeier-Gang verursachen mehr Schaden",
  	 	 	 	"eng": "Enemies of Scavengers gang deals increased damage to you"
  	 	 	}
  	 	},
@@ -4518,7 +4518,7 @@
  	 	 	"vars": [
  	 	 	 	"globalQuestPoint"
  	 	 	],
- 	 	 	"trans": "${globalQuestPoint} SL-Datenklau Fortschritt",
+ 	 	 	"trans": "${globalQuestPoint} SL-Datenk Diebstahl Fortschritt",
  	 	 	"eng": "${globalQuestPoint} SL Data Fortress breach progress"
  	 	}
  	},
@@ -4696,7 +4696,7 @@
  	},
  	"itemStack": {
  	 	"scrap": {
- 	 	 	"trans": "Schrott",
+ 	 	 	"trans": "verschrotten",
  	 	 	"eng": "scrap"
  	 	},
  	 	"destroy": {
@@ -4723,7 +4723,7 @@
  	 	 	 	"eng": "Discard"
  	 	 	},
  	 	 	"warning": {
- 	 	 	 	"trans": "Der obige Gegenstand wird verworfen und nicht in dein Inventar gelegt. Diese Aktion ist dauerhaft.",
+ 	 	 	 	"trans": "Der obige Gegenstand wird verworfen und nicht in dein Inventar gelegt. Diese Aktion kann nicht rückgängig gemacht werden.",
  	 	 	 	"eng": "The item/items above will be discarded and not be placed into your inventory. This action is irreversible."
  	 	 	}
  	 	},
@@ -4960,7 +4960,7 @@
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Passe das Gangbild an",
+ 	 	 	 	 	"trans": "Passe das Gangfoto an",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
@@ -5000,7 +5000,7 @@
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Passe das Gangbild an",
+ 	 	 	 	 	"trans": "Passe das Gangfoto an",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
@@ -5048,7 +5048,7 @@
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"10": {
- 	 	 	 	 	"trans": "Anpassen von Gangbild",
+ 	 	 	 	 	"trans": "Passe das Gangfoto an",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"11": {
@@ -5092,7 +5092,7 @@
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Anpassen von Bandabbild",
+ 	 	 	 	 	"trans": "Passe das Gangfoto an",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
@@ -5120,15 +5120,15 @@
  	 	 	"eng": "helmet"
  	 	},
  	 	"upperArmor": {
- 	 	 	"trans": "Rüstung (Torso)",
+ 	 	 	"trans": "Jacke",
  	 	 	"eng": "upper armor"
  	 	},
  	 	"lowerArmor": {
- 	 	 	"trans": "Rüstung (Beine)",
+ 	 	 	"trans": "Hose",
  	 	 	"eng": "lower armor"
  	 	},
  	 	"boots": {
- 	 	 	"trans": "Stiefel",
+ 	 	 	"trans": "Schuhe",
  	 	 	"eng": "boots"
  	 	},
  	 	"backpack": {
@@ -5405,7 +5405,7 @@
  	 	 	"eng": "of Healing"
  	 	},
  	 	"criticalDamageWeapon": {
- 	 	 	"trans": "von Kritikernschäden",
+ 	 	 	"trans": "des Kritischenschadens",
  	 	 	"eng": "of Crit Damage"
  	 	},
  	 	"upgradeHealth": {
@@ -5421,7 +5421,7 @@
  	 	 	"eng": "of Shield"
  	 	},
  	 	"upgradeSneaky": {
- 	 	 	"trans": "schleichend",
+ 	 	 	"trans": "des schleichens",
  	 	 	"eng": "of Sneaking"
  	 	},
  	 	"upgradeHealthRegen": {
@@ -5433,7 +5433,7 @@
  	 	 	"eng": "of Stun"
  	 	},
  	 	"upgradeCriticalChance": {
- 	 	 	"trans": "der Chance kritisch zu treffen",
+ 	 	 	"trans": "der kritisch Trefferchance",
  	 	 	"eng": "of Crit Chance"
  	 	},
  	 	"upgradeCriticalDamage": {
@@ -5501,7 +5501,7 @@
  	 	 	 	"eng": "Disruptor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Erhöhter Schäden an Voodoo-Boys-Gang. Erhalte mehr Schaden durch Tierbanden.",
+ 	 	 	 	"trans": "Erhöhter Schäden an Voodoo-Boys-Gang. Erhalte mehr Schaden durch Tiere-Bande.",
  	 	 	 	"eng": "deals increased damage to Voodoo Boys gang. receives increased damage from Animals gang."
  	 	 	}
  	 	},
@@ -5511,7 +5511,7 @@
  	 	 	 	"eng": "Makeshift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Erhöhter Schäden an Scavengers-Gang. Erhalte mehr Schaden durch Voodoo-Boys-Gang.",
+ 	 	 	 	"trans": "Erhöhter Schäden an Aasgeier-Gang. Erhalte mehr Schaden durch Voodoo-Boys-Gang.",
  	 	 	 	"eng": "deals increased damage to Scavengers gang. receives increased damage from Voodoo Boys gang."
  	 	 	}
  	 	}
@@ -5519,7 +5519,7 @@
  	"npcGangs": {
  	 	"gang1": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Tier",
+ 	 	 	 	"trans": "Tiere",
  	 	 	 	"eng": "Animals"
  	 	 	}
  	 	},
@@ -5531,7 +5531,7 @@
  	 	},
  	 	"gang3": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Sänger",
+ 	 	 	 	"trans": "Aasgeier",
  	 	 	 	"eng": "Scavengers"
  	 	 	}
  	 	}
@@ -5577,7 +5577,7 @@
  	 	 	 	 	"enemyName",
  	 	 	 	 	"value"
  	 	 	 	],
- 	 	 	 	"trans": "${enemyName} griffen Sie an, erhielt ${value} Schaden",
+ 	 	 	 	"trans": "${enemyName} griffen Sie an, Sie haben ${value} Schaden genommen.",
  	 	 	 	"eng": "${enemyName} attacked you, received ${value} damage"
  	 	 	},
  	 	 	"playerAttack": {
@@ -5585,7 +5585,7 @@
  	 	 	 	 	"enemyName",
  	 	 	 	 	"value"
  	 	 	 	],
- 	 	 	 	"trans": "Sie haben ${enemyName} angegriffen, um ${value} Schaden zu handeln",
+ 	 	 	 	"trans": "Sie haben ${enemyName} angegriffen und ${value} Schaden verursacht.",
  	 	 	 	"eng": "You attacked ${enemyName}, dealing ${value} damage"
  	 	 	}
  	 	}


### PR DESCRIPTION
I found some stuff with help of the German community that needs a change :)

the gang "tag" would be a "Kürzel".
Escape means Flucht, small translation error.

verschrotten means "to scrap" and would be more fitting for scrapping items

Diese Aktion kann nicht rückgängig gemacht werden is more in line with the meaning of "action is irrevisible".

Gangfoto is more inline with the ranslation of "gang image".

Updating Helm/Jacke/Hose/Schuhe so its called the same everywhere.

Here some better word to word translations:
des Kritischenschadens is one to one translation of "Crit Damage"
des schleichens is one to one translation of "of sneaking".
der kritisch Trefferchance is one to one translation of "Crit Chance".

Animals -Tiere is just grammatical error, bc "Tier" is singular.
Scavengers in german means Aasgeier, not Sänger (eng: singer).
i also changed the all sentences where those words were wrongly used or the English versions used.

Some better Sentences to improve Fight log.
",erhielt Value Schaden" is grammatically wrong and is also missing words in german to clarify who has taken dmg.
 "Sie haben ${value} Schaden genommen." would be more in line with the English version.

 um ${value} Schaden zu handeln means to trade VALUE, just a translation error. "und VALUE Schaden verursacht would be, "and dealt VALUE dmg". Doesn't sound right in English but in German it sounds correct.