### PR TITLE
Update it.json

### DIFF
--- a/contribution/lang/it.json
+++ b/contribution/lang/it.json
@@ -13,7 +13,7 @@
  	 	 	"eng": "Quest"
  	 	},
  	 	"chat": {
- 	 	 	"trans": "Chiacchierata",
+ 	 	 	"trans": "Chat",
  	 	 	"eng": "Chat"
  	 	},
  	 	"profile": {
@@ -49,7 +49,7 @@
  	 	 	"editMotto": {
  	 	 	 	"modal": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Per favore inserisci il motto della tue Gang",
+ 	 	 	 	 	 	"trans": "Per favore inserisci il motto della tua Gang",
  	 	 	 	 	 	"eng": "Please enter your gang motto"
  	 	 	 	 	}
  	 	 	 	},
@@ -128,11 +128,11 @@
  	 	 	"colors": {
  	 	 	 	"win": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Decrittografia riuscita",
+ 	 	 	 	 	 	"trans": "Decodifica riuscita",
  	 	 	 	 	 	"eng": "Decryption successful"
  	 	 	 	 	},
  	 	 	 	 	"description": {
- 	 	 	 	 	 	"trans": "in lavorazione",
+ 	 	 	 	 	 	"trans": "in elaborazione",
  	 	 	 	 	 	"eng": "processing"
  	 	 	 	 	}
  	 	 	 	},
@@ -156,7 +156,7 @@
  	 	 	 	},
  	 	 	 	"lose": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Decrittografia fallita",
+ 	 	 	 	 	 	"trans": "Decodifica fallita",
  	 	 	 	 	 	"eng": "Decryption failed"
  	 	 	 	 	},
  	 	 	 	 	"description": {
@@ -174,7 +174,7 @@
  	 	},
  	 	"supportUkraine": {
  	 	 	"description": {
- 	 	 	 	"trans": "Le persone dell'Ucraina, la Russia e il mondo intero stanno soffrendo a causa dell'ambizione di un uomo. \\ N Fai l'amore, non la guerra.",
+ 	 	 	 	"trans": "Le persone dell'Ucraina, la Russia e il mondo intero stanno soffrendo a causa dell'ambizione di un uomo. \\n Fai l'amore, non la guerra.",
  	 	 	 	"eng": "People of Ukraine, Russia and the whole world are suffering because one man's ambition.\\n Make love exploit, not war."
  	 	 	}
  	 	},
@@ -184,7 +184,7 @@
  	 	 	 	"eng": "balance"
  	 	 	},
  	 	 	"deposit": {
- 	 	 	 	"trans": "Depositare",
+ 	 	 	 	"trans": "Deposito",
  	 	 	 	"eng": "Deposit"
  	 	 	},
  	 	 	"depositDesc": {
@@ -192,7 +192,7 @@
  	 	 	 	"eng": "Put Bitcoins into bank"
  	 	 	},
  	 	 	"withdraw": {
- 	 	 	 	"trans": "Ritirare",
+ 	 	 	 	"trans": "Ritiro",
  	 	 	 	"eng": "Withdraw"
  	 	 	},
  	 	 	"withdrawDesc": {
@@ -200,7 +200,7 @@
  	 	 	 	"eng": "Take Bitcoins out of bank"
  	 	 	},
  	 	 	"putItemToVault": {
- 	 	 	 	"trans": "Depositare oggetti",
+ 	 	 	 	"trans": "Deposito oggetti",
  	 	 	 	"eng": "Deposit Item"
  	 	 	},
  	 	 	"putItemToVaultDesc": {
@@ -208,7 +208,7 @@
  	 	 	 	"eng": "Put items into your vault"
  	 	 	},
  	 	 	"takeItemFromVault": {
- 	 	 	 	"trans": "Ritirare oggetti",
+ 	 	 	 	"trans": "Ritiro oggetti",
  	 	 	 	"eng": "Withdraw Item"
  	 	 	},
  	 	 	"takeItemFromVaultDesc": {
@@ -226,7 +226,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"upgradeToSlot"
  	 	 	 	],
- 	 	 	 	"trans": "Aumentare la quantità massima di oggetti che puoi conservare nel caveau a ${upgradeToSlot}",
+ 	 	 	 	"trans": "Aumenta la quantità massima di oggetti che puoi conservare nel caveau a ${upgradeToSlot}",
  	 	 	 	"eng": "Increase the max amount of items you can store in vault to ${upgradeToSlot}"
  	 	 	},
  	 	 	"modal": {
@@ -268,7 +268,7 @@
  	 	 	 	},
  	 	 	 	"tertiary": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Distruggere.",
+ 	 	 	 	 	 	"trans": "Distruttore.",
  	 	 	 	 	 	"eng": "Destruct."
  	 	 	 	 	}
  	 	 	 	}
@@ -313,11 +313,11 @@
  	 	 	 	"eng": "Links are not allowed"
  	 	 	},
  	 	 	"spamBlock": {
- 	 	 	 	"trans": "Si prega di non inviare un messaggio senza senso, gli spam saranno disattivati.",
+ 	 	 	 	"trans": "Si prega di non inviare un messaggio senza senso, gli spammer saranno disattivati.",
  	 	 	 	"eng": "Please do not send meaningless message, spams will be muted."
  	 	 	},
  	 	 	"repeatBlock": {
- 	 	 	 	"trans": "Si prega di non inviare ripetutamente lo stesso messaggio, gli spam saranno disattivati.",
+ 	 	 	 	"trans": "Si prega di non inviare ripetutamente lo stesso messaggio, gli spammer saranno disattivati.",
  	 	 	 	"eng": "Please do not send the same message repeatedly, spams will be muted."
  	 	 	},
  	 	 	"shortChatBlock": {
@@ -354,7 +354,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"name"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "${name} Sta per esaurire in pochi secondi!",
+ 	 	 	 	 	"trans": "${name} si esaurirà entro pochi secondi!",
  	 	 	 	 	"eng": "${name} is about to run out in a few seconds!"
  	 	 	 	},
  	 	 	 	"refresh": {
@@ -379,7 +379,7 @@
  	 	 	 	"eng": "SL Medical Center"
  	 	 	},
  	 	 	"title": {
- 	 	 	 	"trans": "Flatlined!",
+ 	 	 	 	"trans": "Sei morto",
  	 	 	 	"eng": "Flatlined"
  	 	 	},
  	 	 	"subTitleSmall": {
@@ -393,14 +393,14 @@
  	 	},
  	 	"equipmentDisplay": {
  	 	 	"empty": {
- 	 	 	 	"trans": "Vuota",
+ 	 	 	 	"trans": "Vuoto",
  	 	 	 	"eng": "Empty"
  	 	 	}
  	 	},
  	 	"equipment": {
  	 	 	"lowPrintLevelTip": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Rango di stampa basso",
+ 	 	 	 	 	"trans": "Rango di stampa troppo basso",
  	 	 	 	 	"eng": "Low Printing Rank"
  	 	 	 	}
  	 	 	},
@@ -525,7 +525,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Lo Skip Globale consente di saltare il tempo di attesa AFK e terminare immediatamente l\\'attività. \n     Questo effetto sarà applicato a tutti i giocatori che eseguono attività AFK",
+ 	 	 	 	"trans": "Lo Skip Globale consente di saltare il tempo di attesa AFK e terminare immediatamente l\\'attività.\r\n     Questo effetto sarà applicato a tutti i giocatori che eseguono attività AFK",
  	 	 	 	"eng": "Global Skip allow you to skip the AFK waiting time, and finish it instantly.\r\n    this effect will be applied to all players performing an AFK task"
  	 	 	}
  	 	},
@@ -546,7 +546,7 @@
  	 	 	},
  	 	 	"autoScrap": {
  	 	 	 	"button": {
- 	 	 	 	 	"trans": "Auto-rottama",
+ 	 	 	 	 	"trans": "Rottamazione automatica",
  	 	 	 	 	"eng": "Auto Scrap"
  	 	 	 	}
  	 	 	},
@@ -570,7 +570,7 @@
  	 	"communityItemLore": {
  	 	 	"noLoreButton": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Creare un conutenuto",
+ 	 	 	 	 	"trans": "Creare un contenuto",
  	 	 	 	 	"eng": "Create Lore"
  	 	 	 	},
  	 	 	 	"description": {
@@ -663,7 +663,7 @@
  	 	 	},
  	 	 	"factoryReset": {
  	 	 	 	"confirmation": {
- 	 	 	 	 	"trans": "Questo ripristinerà tutta la calibrazione sul tuo oggetto. Lo renderà anche nuovamente commerciabile. \n       Sei sicuro di voler procedere?",
+ 	 	 	 	 	"trans": "Questo ripristinerà tutta la calibrazione sul tuo oggetto. Lo renderà anche nuovamente commerciabile. \r\n       Sei sicuro di voler procedere?",
  	 	 	 	 	"eng": "Doing this will reset all calibration on your item. It will also make it tradable again. \r\n      Are you sure you want to proceed?"
  	 	 	 	},
  	 	 	 	"trans": "Reset di fabbrica",
@@ -5649,7 +5649,7 @@
  	 	},
  	 	"equipmentQuickMenu": {
  	 	 	"unequip": {
- 	 	 	 	"trans": "inequivoca",
+ 	 	 	 	"trans": "rimuovi",
  	 	 	 	"eng": "unequip"
  	 	 	},
  	 	 	"viewDetails": {
@@ -5657,7 +5657,7 @@
  	 	 	 	"eng": "View Details"
  	 	 	},
  	 	 	"swap": {
- 	 	 	 	"trans": "sostituire le attrezzature",
+ 	 	 	 	"trans": "sostituire l'attrezzatura",
  	 	 	 	"eng": "replace equipment"
  	 	 	}
  	 	},


### PR DESCRIPTION
fixed some typos. improved some translations. 
Some words do not require a literal translation in italian (i.e. Chat is a neologism, it shouldn't even be translated; unequip has no real translation in our language), so I translated them with what sounds better in italian.

Added back some carriage returns (i.e. \r) that were missing from translated text, mainly because they were written in the "eng" text.