### PR TITLE
Updated EN Procedural Names

### DIFF
--- a/contribution/mobile/en/procedural-names.json
+++ b/contribution/mobile/en/procedural-names.json
@@ -454,7 +454,7 @@
 				"War Helm",
 				"Waterproof Hood",
 				"Boots",
-				"Fursuit head"
+				"Fursuit Head"
 			]
 		},
 		"UPPER_ARMOR": {
@@ -540,7 +540,7 @@
 				"Flat Cookie Earth T-Shirt",
 				"Fred Shirt",
 				"Frilly Shirt",
-				"Fursuit",
+				"Fursuit Body",
 				"Gander Armor",
 				"Gantz Suit",
 				"Gato Suit",
@@ -704,6 +704,7 @@
 				"Daisy Dukes",
 				"Denim Cut-Offs",
 				"Diamond Leggings",
+				"Digitigrade Fursuit Legs",
 				"Dorph-Infused Leggings",
 				"Dorph-Infused Miniskirt",
 				"Dorph-Infused Pants",
@@ -713,7 +714,6 @@
 				"Fig Leaf",
 				"Fishnet Tights",
 				"Frog Overalls",
-				"Fursuit Pants",
 				"G-String",
 				"Gantz Pants",
 				"Hacked Cybernetic Legs",
@@ -747,6 +747,7 @@
 				"Pants",
 				"Pencil Skirt",
 				"Pirate Breeches",
+				"Plantigrade Fursuit Legs",
 				"Pleated Skirt",
 				"Plugsuit Leggings",
 				"President Slacks",
@@ -887,7 +888,7 @@
 				"Yeezy's",
 				"Jowdan's",
 				"Hat",
-				"Fursuit Paws"
+				"Fursuit Feetpaws"
 			]
 		}
 	},


### PR DESCRIPTION
Fixed the Fursuit names.

-Changed "Fursuit" to "Fursuit Body", because it's just one piece of the whole set. "Fursuit" would mean it's the whole set.
-Split "Fursuit Pants" into Plantigrade and Digitigrade Fursuit Legs. Not just to have two varieties, but also to reflect what they're actually called. "Fursuit Pants" are not a thing.
-Reverted "Fursuit Paws" to "Fursuit Feetpaws". Sorry Krolik, they're called Feetpaws. We all call them that.