### PR TITLE
Updated EN Procedural Names

### DIFF
--- a/contribution/mobile/en/procedural-names.json
+++ b/contribution/mobile/en/procedural-names.json
@@ -13,7 +13,9 @@
 				"Compromised",
 				"Corrupted",
 				"Subpar",
-				"Rejected"
+				"Rejected",
+				"Obsolete",
+				"Defective"
 			]
 		},
 		"COMMON": {


### PR DESCRIPTION
Added two **TRASH**-tier prefixes: _"Obsolete"_ and _"Defective"_.