### PR TITLE
DE fixes around Units and costs

### DIFF
--- a/contribution/lang/de.json
+++ b/contribution/lang/de.json
@@ -2364,7 +2364,7 @@
  	 	 	"eng": "Available again in ${time}"
  	 	},
  	 	"free": {
- 	 	 	"trans": "Frei",
+ 	 	 	"trans": "Kostenlos",
  	 	 	"eng": "Free"
  	 	},
  	 	"luna": {
@@ -2448,7 +2448,7 @@
  	 	 	 	"eng": "Increase your EXP gain by 80% for 20 minutes"
  	 	 	},
  	 	 	"button": {
- 	 	 	 	"trans": "aktivieren Sie",
+ 	 	 	 	"trans": "aktivieren",
  	 	 	 	"eng": "Activate"
  	 	 	}
  	 	}
@@ -3261,7 +3261,7 @@
  	},
  	"priceTag": {
  	 	"free": {
- 	 	 	"trans": "FREI",
+ 	 	 	"trans": "KOSTENLOS",
  	 	 	"eng": "FREE"
  	 	}
  	},
@@ -3281,7 +3281,7 @@
  	},
  	"slider": {
  	 	"min": {
- 	 	 	"trans": "Mindest",
+ 	 	 	"trans": "Min",
  	 	 	"eng": "Min"
  	 	},
  	 	"max": {
@@ -7015,7 +7015,7 @@
  	 	},
  	 	"freeButton": {
  	 	 	"text": {
- 	 	 	 	"trans": "Anspruch kostenlos",
+ 	 	 	 	"trans": "Kostenlos beanspruchen",
  	 	 	 	"eng": "Claim for free"
  	 	 	}
  	 	},
@@ -7146,11 +7146,11 @@
  	},
  	"referralPromo": {
  	 	"title": {
- 	 	 	"trans": "Verweisen Sie Ihre Freunde, um erstaunliche Belohnungen zu erhalten!",
+ 	 	 	"trans": "Verweisen Sie Ihre Freunde, um großartige Belohnungen zu erhalten!",
  	 	 	"eng": "Refer your friends to get amazing rewards!"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "Freie Einheit*",
+ 	 	 	"trans": "Kostenlose Unit*",
  	 	 	"eng": "Free Unit*"
  	 	},
  	 	"desc2": {
@@ -7172,7 +7172,7 @@
  	 	 	}
  	 	},
  	 	"footnote1": {
- 	 	 	"trans": "*Sie erhalten 10% Bonuseinheit, wenn Ihr Freund Einheit kauft",
+ 	 	 	"trans": "*Sie erhalten 10% Bonus Units, wenn Ihr Freund Units kauft",
  	 	 	"eng": "*you get 10% bonus unit whenever your friend purchases unit"
  	 	},
  	 	"footnote2": {
@@ -7279,7 +7279,7 @@
  	},
  	"craftingStartPage": {
  	 	"instant": {
- 	 	 	"trans": "Sofortig",
+ 	 	 	"trans": "Sofort",
  	 	 	"eng": "Instant"
  	 	},
  	 	"instantDescription": {
@@ -7407,7 +7407,7 @@
  	 	 	 	 	"playerName",
  	 	 	 	 	"price"
  	 	 	 	],
- 	 	 	 	"trans": "Senden Sie ${donationName} Spenden -Chat -Frame (kostet ${price} Einheit) an Player \"${playerName}\"?",
+ 	 	 	 	"trans": "Senden Sie ${donationName} Spenden -Chat -Frame (kostet ${price} Units) an Player \"${playerName}\"?",
  	 	 	 	"eng": "Send ${donationName} donation chat frame (cost ${price} Unit) to player \"${playerName}\"?"
  	 	 	},
  	 	 	"description": {
@@ -7435,7 +7435,7 @@
  	 	 	"vars": [
  	 	 	 	"price"
  	 	 	],
- 	 	 	"trans": "${price} Einheit",
+ 	 	 	"trans": "${price} Units",
  	 	 	"eng": "${price} Unit"
  	 	},
  	 	"donationDescription": {
@@ -7465,7 +7465,7 @@
  	 	 	 	 	"playerName",
  	 	 	 	 	"price"
  	 	 	 	],
- 	 	 	 	"trans": "Senden Sie Emblem (kostet ${price} Einheit) an Player \"${playerName}\"?",
+ 	 	 	 	"trans": "Senden Sie Emblem (kostet ${price} Units) an Player \"${playerName}\"?",
  	 	 	 	"eng": "Send emblem (cost ${price} Unit) to player \"${playerName}\"?"
  	 	 	},
  	 	 	"description": {


### PR DESCRIPTION
A few more changes around "Units". They should be called Units and not being translated.

"Free" means "Kostenlos" while "Frei" is free as in "Free like a bird".
"Min" and "Max" are the same in this context (UI buttons) in German.