### PR TITLE
fix: better Ukrainian translation

### DIFF
--- a/contribution/lang/uk.json
+++ b/contribution/lang/uk.json
@@ -1,7 +1,7 @@
 {
  	"tabs": {
  	 	"map": {
- 	 	 	"trans": "Карта",
+ 	 	 	"trans": "Мапа",
  	 	 	"eng": "Map"
  	 	},
  	 	"inventory": {
@@ -24,21 +24,21 @@
  	"ui": {
  	 	"blackMarket": {
  	 	 	"selectItemButton": {
- 	 	 	 	"trans": "Друк і продаж",
+ 	 	 	 	"trans": "Роздрукувати та продати",
  	 	 	 	"eng": "Print And Sell"
  	 	 	}
  	 	},
  	 	"clan": {
  	 	 	"selectDepositAmount": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Введіть суму для внесення на рахунок",
+ 	 	 	 	 	"trans": "Будь ласка, введіть суму, яку ви бажаєте внести на рахунок",
  	 	 	 	 	"eng": "Please enter amount you want to deposit"
  	 	 	 	},
  	 	 	 	"detail": {
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"amount"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "${amount} біткойнів буде внесено на рахунок ватаги. Продовжити?",
+ 	 	 	 	 	"trans": "${amount} біткоїнів будуть зараховані на ваш рахунок банди. Продовжити?",
  	 	 	 	 	"eng": "${amount} bitcoin will be deposit into your gang account, this cannot be reversed"
  	 	 	 	}
  	 	 	},
@@ -49,23 +49,23 @@
  	 	 	"editMotto": {
  	 	 	 	"modal": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Введіть девіз ватаги",
+ 	 	 	 	 	 	"trans": "Будь ласка, введіть девіз вашої банди",
  	 	 	 	 	 	"eng": "Please enter your gang motto"
  	 	 	 	 	}
  	 	 	 	},
  	 	 	 	"button": {
- 	 	 	 	 	"trans": "Редагувати девіз ватаги",
+ 	 	 	 	 	"trans": "Редагувати девіз банди",
  	 	 	 	 	"eng": "Edit Gang Motto"
  	 	 	 	}
  	 	 	},
  	 	 	"updateImage": {
  	 	 	 	"button": {
- 	 	 	 	 	"trans": "Оновити зображення ватаги",
+ 	 	 	 	 	"trans": "Оновити зображення банди",
  	 	 	 	 	"eng": "Update Gang Image"
  	 	 	 	}
  	 	 	},
  	 	 	"level": {
- 	 	 	 	"trans": "Рівень ватаги",
+ 	 	 	 	"trans": "Рівень банди",
  	 	 	 	"eng": "Gang Level"
  	 	 	},
  	 	 	"resource": {
@@ -77,22 +77,22 @@
  	 	 	 	"eng": "funding"
  	 	 	},
  	 	 	"memberCount": {
- 	 	 	 	"trans": "членів",
+ 	 	 	 	"trans": "учасників",
  	 	 	 	"eng": "members"
  	 	 	},
  	 	 	"occupationPoint": {
- 	 	 	 	"trans": "Контроль над Шангрі-ла",
+ 	 	 	 	"trans": "Контроль над Шангрі-Ла",
  	 	 	 	"eng": "Control over Shangri-la"
  	 	 	},
  	 	 	"nextUpkeepDate": {
  	 	 	 	"vars": [
  	 	 	 	 	"nextUpkeepDate"
  	 	 	 	],
- 	 	 	 	"trans": "Наступна дата утримання: ${nextUpkeepDate}",
+ 	 	 	 	"trans": "Дата наступного технічного обслуговування: ${nextUpkeepDate}",
  	 	 	 	"eng": "Next upkeep Date: ${nextUpkeepDate}"
  	 	 	},
  	 	 	"insufficientError": {
- 	 	 	 	"trans": "Критична нестача ресурсів",
+ 	 	 	 	"trans": "критична нестача ресурсів",
  	 	 	 	"eng": "resource critical"
  	 	 	},
  	 	 	"insufficientFound": {
@@ -105,22 +105,22 @@
  	 	 	},
  	 	 	"occupation": {
  	 	 	 	"noClan": {
- 	 	 	 	 	"trans": "Зона ще не зайнята ніякою ватагою",
+ 	 	 	 	 	"trans": "Жодна банда ще не захопила цю територію",
  	 	 	 	 	"eng": "No gang has occupied this area yet"
  	 	 	 	}
  	 	 	},
  	 	 	"members": {
- 	 	 	 	"trans": "Члени",
+ 	 	 	 	"trans": "Учасники",
  	 	 	 	"eng": "Members"
  	 	 	}
  	 	},
  	 	"communityContentBox": {
  	 	 	"title": {
- 	 	 	 	"trans": "Контент спільноти гравців",
+ 	 	 	 	"trans": "Контент спільноти",
  	 	 	 	"eng": "Community Content"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Цей контент створено спільнотою гравців. Натисніть тут, щоб внести свій власний допис.",
+ 	 	 	 	"trans": "Цей контент надано спільнотою. Натисніть тут, щоб додати власний контент.",
  	 	 	 	"eng": "This content is contributed by the community. click here to contribute your own content."
  	 	 	}
  	 	},
@@ -137,7 +137,7 @@
  	 	 	 	 	}
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Ви знайшли замкнуту скриню з різнокольоровою клавіатурою, ви можете розблокувати її, якщо правильно введете послідовність кольорів.",
+ 	 	 	 	 	"trans": "Ви знайшли замкнений лутбокс із кольоровою клавіатурою, ви зможете розблокувати його правильною послідовністю кольорів.",
  	 	 	 	 	"eng": "You found a locked loot box with color keypad, you should be able to unlock it with the correct sequence of colors."
  	 	 	 	},
  	 	 	 	"progress": {
@@ -151,21 +151,21 @@
  	 	 	 	 	"eng": "seconds"
  	 	 	 	},
  	 	 	 	"colorBox": {
- 	 	 	 	 	"trans": "Натисніть на цей колір внизу",
+ 	 	 	 	 	"trans": "Натисніть на цей колір нижче",
  	 	 	 	 	"eng": "Click on this color below"
  	 	 	 	},
  	 	 	 	"lose": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Помилка дешифрування",
+ 	 	 	 	 	 	"trans": "Не вдалося розшифрувати",
  	 	 	 	 	 	"eng": "Decryption failed"
  	 	 	 	 	},
  	 	 	 	 	"description": {
- 	 	 	 	 	 	"trans": "Натисніть на правильну послідовність кольорів, щоб розблокувати",
+ 	 	 	 	 	 	"trans": "Натисніть правильну послідовність кольорів, щоб розблокувати",
  	 	 	 	 	 	"eng": "Click on the correct color sequence to unlock"
  	 	 	 	 	},
  	 	 	 	 	"button": {
  	 	 	 	 	 	"title": {
- 	 	 	 	 	 	 	"trans": "Повторити спробу",
+ 	 	 	 	 	 	 	"trans": "Спробувати ще раз",
  	 	 	 	 	 	 	"eng": "Try Again"
  	 	 	 	 	 	}
  	 	 	 	 	}
@@ -174,7 +174,7 @@
  	 	},
  	 	"supportUkraine": {
  	 	 	"description": {
- 	 	 	 	"trans": "Люди України, Росії, та всього світу страждають через амбіції однієї людини.\n Поширюйте любов, не війну",
+ 	 	 	 	"trans": "Через честолюбство однієї людини страждає народ України, росії і всього світу.\\n Поширюйте любов, а не війну.",
  	 	 	 	"eng": "People of Ukraine, Russia and the whole world are suffering because one man's ambition.\\n Make love exploit, not war."
  	 	 	}
  	 	},
@@ -204,7 +204,7 @@
  	 	 	 	"eng": "Deposit Item"
  	 	 	},
  	 	 	"putItemToVaultDesc": {
- 	 	 	 	"trans": "Покласти речі в банківське сховище",
+ 	 	 	 	"trans": "Покласти речі в сховище банку",
  	 	 	 	"eng": "Put items into your vault"
  	 	 	},
  	 	 	"takeItemFromVault": {
@@ -212,7 +212,7 @@
  	 	 	 	"eng": "Withdraw Item"
  	 	 	},
  	 	 	"takeItemFromVaultDesc": {
- 	 	 	 	"trans": "Забрати речі з банківського сховища",
+ 	 	 	 	"trans": "Забрати речі зі сховища банку",
  	 	 	 	"eng": "Take items out from your vault"
  	 	 	},
  	 	 	"upgradeSlot": {
@@ -249,11 +249,11 @@
  	 	 	},
  	 	 	"upgradeVaultModal": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Оновіть сховище",
+ 	 	 	 	 	"trans": "Покращити сховище",
  	 	 	 	 	"eng": "Upgrade Vault"
  	 	 	 	},
  	 	 	 	"confirm": {
- 	 	 	 	 	"trans": "Оновлення",
+ 	 	 	 	 	"trans": "Покращити",
  	 	 	 	 	"eng": "Upgrade"
  	 	 	 	}
  	 	 	},
@@ -266,13 +266,13 @@
  	 	 	"attackButton": {
  	 	 	 	"primary": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Основна",
+ 	 	 	 	 	 	"trans": "головна",
  	 	 	 	 	 	"eng": "primary"
  	 	 	 	 	}
  	 	 	 	},
  	 	 	 	"secondary": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Спец",
+ 	 	 	 	 	 	"trans": "спец",
  	 	 	 	 	 	"eng": "special"
  	 	 	 	 	}
  	 	 	 	},
@@ -346,7 +346,7 @@
  	 	 	 	"eng": "chat"
  	 	 	},
  	 	 	"gang": {
- 	 	 	 	"trans": "ватага",
+ 	 	 	 	"trans": "банда",
  	 	 	 	"eng": "gang"
  	 	 	},
  	 	 	"mail": {
@@ -364,7 +364,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"vpnName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Експлойт для чату діє, всі надіслані повідомлення буде викривлено. Використовуйте ${vpnName}, щоб забезпечити з'єднання!",
+ 	 	 	 	 	"trans": "Діє експлойт чату, усі надіслані повідомлення буде змінено. Використовуйте ${vpnName}, щоб захистити ваше з'єднання!",
  	 	 	 	 	"eng": "Chat exploit is in effect, all message sent will be altered. use ${vpnName} to secure your connection!"
  	 	 	 	},
  	 	 	 	"activateVPN": {
@@ -395,18 +395,18 @@
  	 	"clanPage": {
  	 	 	"createClan": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Ви не є членом жодної ватаги",
+ 	 	 	 	 	"trans": "Ви не є членом жодної банди",
  	 	 	 	 	"eng": "You are not a member of any gang"
  	 	 	 	},
  	 	 	 	"subtitle": {
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"cost"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Чат ватаги буде ввімкнено, коли ви належите до ватаги",
+ 	 	 	 	 	"trans": "груповий чат буде ввімкнено, якщо ви належите до банди.\\nприєднайтеся до банди, знайшовши друзів у глобальному чаті, або створіть власну банду та запросіть своїх друзів!",
  	 	 	 	 	"eng": "gang chat will be enabled when you belong to a gang.\\njoin a gang by making friends in global chat or create your own gang and invite your friends!"
  	 	 	 	},
  	 	 	 	"createButton": {
- 	 	 	 	 	"trans": "Створити ватагу",
+ 	 	 	 	 	"trans": "Створити банду",
  	 	 	 	 	"eng": "Create gang"
  	 	 	 	},
  	 	 	 	"createButtonDescription": {
@@ -414,18 +414,18 @@
  	 	 	 	 	 	"cost",
  	 	 	 	 	 	"currency"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Створіть ватагу за ${cost} ${currency}",
+ 	 	 	 	 	"trans": "Створіть банду за ${cost} ${currency}",
  	 	 	 	 	"eng": "Create a gang for ${cost} ${currency}"
  	 	 	 	}
  	 	 	}
  	 	},
  	 	"deathScreen": {
  	 	 	"topTitleLeft": {
- 	 	 	 	"trans": "Фатальна травма",
+ 	 	 	 	"trans": "смертельна травма",
  	 	 	 	"eng": "fatal injury"
  	 	 	},
  	 	 	"topTitleRight": {
- 	 	 	 	"trans": "Медичний центр Шангрі-ла",
+ 	 	 	 	"trans": "Медичний центр Шангрі-Ла",
  	 	 	 	"eng": "SL Medical Center"
  	 	 	},
  	 	 	"title": {
@@ -467,7 +467,7 @@
  	 	 	 	"eng": "Quick Slots"
  	 	 	},
  	 	 	"equipped": {
- 	 	 	 	"trans": "Обладнання",
+ 	 	 	 	"trans": "Обладнаний",
  	 	 	 	"eng": "Equipped"
  	 	 	}
  	 	},
@@ -581,7 +581,7 @@
  	 	},
  	 	"list": {
  	 	 	"longPressToMultiSelect": {
- 	 	 	 	"trans": "Потримайте для обрання кількох речей",
+ 	 	 	 	"trans": "Натисніть і утримуйте для вибору декількох речей",
  	 	 	 	"eng": "Long press to multi-select"
  	 	 	}
  	 	},
@@ -668,7 +668,7 @@
  	 	 	 	]
  	 	 	},
  	 	 	"areaEffect": {
- 	 	 	 	"trans": "[AoE] Зона ефекту, ефект цього предмету буде застосовано до союзників у бою.",
+ 	 	 	 	"trans": "[AOE] Зона ефекту, ефект цього предмету буде застосовано до союзників у бою.",
  	 	 	 	"eng": "[AOE] Area of Effect, the effect of this item will apply allies in combat with you."
  	 	 	},
  	 	 	"equip": {
@@ -719,11 +719,11 @@
  	 	 	 	"eng": "Unlock Container"
  	 	 	},
  	 	 	"cantOpenContainerNotIdleV2": {
- 	 	 	 	"trans": "Ви не можете розблокувати контейнери, поки зараз",
+ 	 	 	 	"trans": "Ви не можете розблокувати контейнери прямо зараз",
  	 	 	 	"eng": "You cannot unlock containers right now"
  	 	 	},
  	 	 	"openRedEnvelop": {
- 	 	 	 	"trans": "ВІДЧИНЕНО",
+ 	 	 	 	"trans": "Відкрити",
  	 	 	 	"eng": "Open"
  	 	 	},
  	 	 	"cannotOpenRedEnvelopNotIdle": {
@@ -741,7 +741,7 @@
  	 	 	},
  	 	 	"itemUpgradeButton": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Вдосконалити",
+ 	 	 	 	 	"trans": "вдосконалити",
  	 	 	 	 	"eng": "upgrade"
  	 	 	 	}
  	 	 	},
@@ -759,7 +759,7 @@
  	 	 	 	 	"eng": "You no longer have this item"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Натисніть назад, щоб повернутися до інвентаря",
+ 	 	 	 	 	"trans": "натисніть назад, щоб повернутися до інвентарю",
  	 	 	 	 	"eng": "press back to go back to inventory"
  	 	 	 	}
  	 	 	}
@@ -770,7 +770,7 @@
  	 	 	 	"eng": "Secret Keys"
  	 	 	},
  	 	 	"noKeysTitle": {
- 	 	 	 	"trans": "У вас немає таємних ключів",
+ 	 	 	 	"trans": "У вас немає жодних таємних ключів",
  	 	 	 	"eng": "You don't have any secret keys"
  	 	 	},
  	 	 	"noKeysSubtitle": {
@@ -799,7 +799,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"hiddenCount"
  	 	 	 	],
- 	 	 	 	"trans": "Є ще ${hiddenCount} речей доступних для використання в цій локації, підвищіть свій рівень, щоб їх розблокувати.",
+ 	 	 	 	"trans": "Є ще ${hiddenCount} речей доступних для використання в цій локації, підвищте свій рівень, щоб їх розблокувати.",
  	 	 	 	"eng": "${hiddenCount} more interactables can be unlocked at this location, level up to unlock them."
  	 	 	},
  	 	 	"travel": {
@@ -862,7 +862,7 @@
  	 	},
  	 	"playerDetails": {
  	 	 	"alias": {
- 	 	 	 	"trans": "Псевдонім",
+ 	 	 	 	"trans": "Кличка",
  	 	 	 	"eng": "Alias"
  	 	 	},
  	 	 	"title": {
@@ -898,7 +898,7 @@
  	 	 	 	"eng": "REDACTED"
  	 	 	},
  	 	 	"decoration1": {
- 	 	 	 	"trans": "Конфіденційний",
+ 	 	 	 	"trans": "конфіденційно",
  	 	 	 	"eng": "confidential"
  	 	 	},
  	 	 	"decoration2": {
@@ -918,7 +918,7 @@
  	 	 	},
  	 	 	"gangAction": {
  	 	 	 	"label": {
- 	 	 	 	 	"trans": "Керування ватагою",
+ 	 	 	 	 	"trans": "Керування бандою",
  	 	 	 	 	"eng": "Gang Actions"
  	 	 	 	},
  	 	 	 	"kick": {
@@ -948,11 +948,11 @@
  	 	 	 	 	"eng": "Send Gift"
  	 	 	 	},
  	 	 	 	"sendCosmetic": {
- 	 	 	 	 	"trans": "Надішліть косметичний подарунок",
+ 	 	 	 	 	"trans": "Надіслати косметичний подарунок",
  	 	 	 	 	"eng": "Send Cosmetic Gift"
  	 	 	 	},
  	 	 	 	"inviteToGang": {
- 	 	 	 	 	"trans": "Запросити до ватаги",
+ 	 	 	 	 	"trans": "Запросити до банди",
  	 	 	 	 	"eng": "Invite to Gang"
  	 	 	 	},
  	 	 	 	"addToFriend": {
@@ -1000,7 +1000,7 @@
  	 	 	},
  	 	 	"upgradeSuccess": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Калібрування вдале",
+ 	 	 	 	 	"trans": "Калібрування пройшло успішно",
  	 	 	 	 	"eng": "Calibration Success"
  	 	 	 	},
  	 	 	 	"subtitle": {
@@ -1049,7 +1049,7 @@
  	 	 	 	"eng": "Spend Bitcoins to increase how many items you can put in your stall at the same time"
  	 	 	},
  	 	 	"cantEnterError": {
- 	 	 	 	"trans": "Ви повинні бути принаймні 4го рівня, щоб отримати доступ до ринку",
+ 	 	 	 	"trans": "Ви повинні бути принаймні 4-го рівня, щоб отримати доступ до ринку",
  	 	 	 	"eng": "You need to be at least level 4 to access the market"
  	 	 	},
  	 	 	"levelSelect": {
@@ -1065,7 +1065,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"noItems": {
- 	 	 	 	"trans": "Поки що немає речей цієї категорії на продажу",
+ 	 	 	 	"trans": "наразі немає товарів у продажу для цієї категорії",
  	 	 	 	"eng": "there is currently no items on sale for this category"
  	 	 	},
  	 	 	"buy": {
@@ -1121,11 +1121,11 @@
  	 	 	 	}
  	 	 	},
  	 	 	"abortWarningTitle": {
- 	 	 	 	"trans": "Ви впевнені, що хочете скасувати?",
+ 	 	 	 	"trans": "Ви впевнені, що хочете перервати?",
  	 	 	 	"eng": "Are you sure you want to abort?"
  	 	 	},
  	 	 	"abortWarning": {
- 	 	 	 	"trans": "використані матеріали будуть втрачені при скасуванні",
+ 	 	 	 	"trans": "Скасувавши це, ви не отримаєте жодної винагороди, а використаний матеріал не буде повернено",
  	 	 	 	"eng": "By aborting this you won\\'t receive any reward and the material used won\\'t be returned"
  	 	 	}
  	 	},
@@ -1135,7 +1135,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"gangName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Під контролем ватаги ${gangName}",
+ 	 	 	 	 	"trans": "Під контролем банди ${gangName}",
  	 	 	 	 	"eng": "Occupied by ${gangName}"
  	 	 	 	},
  	 	 	 	"occupationPoints": {
@@ -1169,7 +1169,7 @@
  	 	 	 	 	 	"eng": "Get even better equipments!"
  	 	 	 	 	},
  	 	 	 	 	"description": {
- 	 	 	 	 	 	"trans": "Ваше поточне обладнання здається трохи застарілим для вашого рівня, спробуйте друкувати сильніші речі",
+ 	 	 	 	 	 	"trans": "Ваше поточне обладнання здається трохи застарілим для вашого рівня, спробуйте друкувати сильніші речі на заміну",
  	 	 	 	 	 	"eng": "Your current equipment seems abit outdated for your level, try printing stronger ones to replace them"
  	 	 	 	 	}
  	 	 	 	},
@@ -1208,14 +1208,14 @@
  	 	 	 	},
  	 	 	 	"common": {
  	 	 	 	 	"clickToOpen": {
- 	 	 	 	 	 	"trans": "Натисніть, щоб відкрити",
+ 	 	 	 	 	 	"trans": "натисніть, щоб відкрити",
  	 	 	 	 	 	"eng": "click to open"
  	 	 	 	 	}
  	 	 	 	}
  	 	 	},
  	 	 	"globalQuest": {
  	 	 	 	"progressTitle": {
- 	 	 	 	 	"trans": "Кібератака Фортеці Даних Шангрі-ла",
+ 	 	 	 	 	"trans": "Кібератака Фортеці Даних Шангрі-Ла",
  	 	 	 	 	"eng": "SL-Data Fortress Breach"
  	 	 	 	},
  	 	 	 	"infoBox": {
@@ -1224,7 +1224,7 @@
  	 	 	 	 	 	"eng": "Cyberspace breach in progress"
  	 	 	 	 	},
  	 	 	 	 	"subtitle": {
- 	 	 	 	 	 	"trans": "Об'єднайтесь з іншими Нетранерами, щоб прорватись до Фортеці Даних Шангрі-ла, і надати баф усім гравцям",
+ 	 	 	 	 	 	"trans": "Об'єднайтесь з іншими Нетранерами, щоб прорватись до Фортеці Даних Шангрі-Ла, і надати баф усім гравцям",
  	 	 	 	 	 	"eng": "Join forces with other Netrunners to breach the SL-Data Fortress to grant all players with buff"
  	 	 	 	 	}
  	 	 	 	},
@@ -1234,7 +1234,7 @@
  	 	 	 	 	 	"eng": "Breach operation completed"
  	 	 	 	 	},
  	 	 	 	 	"subtitle": {
- 	 	 	 	 	 	"trans": "Розгортається віддалений експлойт, будь ласка, зачекайте ...",
+ 	 	 	 	 	 	"trans": "Розгортання віддаленого експлойта, зачекайте...",
  	 	 	 	 	 	"eng": "Remote exploit deploying, please wait..."
  	 	 	 	 	}
  	 	 	 	}
@@ -1242,7 +1242,7 @@
  	 	},
  	 	"mobileQuestPage": {
  	 	 	"rewards": {
- 	 	 	 	"trans": "Винагороди",
+ 	 	 	 	"trans": "винагороди",
  	 	 	 	"eng": "rewards"
  	 	 	},
  	 	 	"rewardAvailable": {
@@ -1292,7 +1292,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"content": {
- 	 	 	 	"trans": "Якщо у вас виникли питання, будь ласка, зв'яжіться з Dexter безпосередньо за допомогою офіційного Discord серверу (посилання можна знайти в плаваючому меню -> посилання) або електронною поштою, за адресою ching.huang.dexter@gmail.com",
+ 	 	 	 	"trans": "Якщо у вас виникли питання, будь ласка, зв'яжіться з Dexter безпосередньо за допомогою офіційного Discord серверу (посилання можна знайти в Плаваючому Меню -> Посилання) або електронною поштою, за адресою ching.huang.dexter@gmail.com",
  	 	 	 	"eng": "If you have any questions please feel free to contact Dexter directly via official Discord (Link can be found in Floating Menu -> Links) or email to ching.huang.dexter@gmail.com"
  	 	 	}
  	 	},
@@ -1321,7 +1321,7 @@
  	 	"machineCrafting": {
  	 	 	"titleBox": {
  	 	 	 	"tile": {
- 	 	 	 	 	"trans": "система бездіяльна",
+ 	 	 	 	 	"trans": "система в режимі очікування",
  	 	 	 	 	"eng": "system idle"
  	 	 	 	},
  	 	 	 	"subtitle": {
@@ -1370,7 +1370,7 @@
  	 	"setting": {
  	 	 	"langWarning": {
  	 	 	 	"trans": "Цей мовний пакет є в відкритому доступі, і дописується нашими гравцями. Текст може бути перекладений частково, або з помилками. Якщо бажаєте, можете додати поправки і допомогти на нашій Github сторінці",
- 	 	 	 	"eng": "This language pack is open source and contributed by our players, the text may not be fully translated and could contain mistakes. please feel free to edit and contribute from our Github page"
+ 	 	 	 	"eng": "Цей мовний пакет є відкритим кодом і наданий нашими гравцями, текст може бути перекладений не повністю та містити помилки. Будь ласка, не соромтеся редагувати та робити внески на нашій сторінці GitHub."
  	 	 	},
  	 	 	"langGithub": {
  	 	 	 	"trans": "Допомогти з перекладом гри",
@@ -1427,7 +1427,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"receiveClanNotification": {
- 	 	 	 	"trans": "Отримувати сповіщення про ватагу",
+ 	 	 	 	"trans": "Отримувати сповіщення про банду",
  	 	 	 	"eng": "Receive Gang Notification"
  	 	 	},
  	 	 	"receiveGlobalNotification": {
@@ -1491,7 +1491,7 @@
  	 	},
  	 	"job": {
  	 	 	"cantEnterError": {
- 	 	 	 	"trans": "Ви повинні бути принаймні 2го рівня, щоб отримати доступ до Комерційної зони",
+ 	 	 	 	"trans": "Ви повинні бути принаймні 2-го рівня, щоб отримати доступ до Комерційної зони",
  	 	 	 	"eng": "You need to be at least level 2 to access the job hub"
  	 	 	}
  	 	},
@@ -1502,7 +1502,7 @@
  	 	 	 	 	"eng": "Cancel Afk and logout?"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Ви впевнені, що хочете скасувати свій AFK та вийти? Ресурс, який використовується для запуску завдання, не буде повернено.",
+ 	 	 	 	 	"trans": "Ви впевнені, що бажаєте скасувати AFK і вийти? Ресурси, використані для запуску завдання, НЕ повернуться.",
  	 	 	 	 	"eng": "Are you sure you want to cancel your afk and logout? the resource used to start the task will NOT be refunded."
  	 	 	 	}
  	 	 	}
@@ -1549,7 +1549,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"percent"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Ви впевнені, що хочете калібрувати цю річ з ризиком руйнівної невдачі у ${percent}%?",
+ 	 	 	 	 	"trans": "Ви впевнені, що хочете калібрувати цю річ? Ризик руйнівної невдачі - ${percent}%.",
  	 	 	 	 	"eng": "Are you sure you want to calibrate this item with ${percent}% destructive failure chance?"
  	 	 	 	}
  	 	 	}
@@ -1567,7 +1567,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"cost"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Призначення рангового банди коштуватиме вам ${cost} BTC і вимагатиме перезапуску гри, щоб побачити зміни",
+ 	 	 	 	 	"trans": "Призначення рангу банди коштуватиме вам ${cost} біткойнів і потребує перезапуску гри, щоб побачити зміни",
  	 	 	 	 	"eng": "Assigning a gang rank will cost you ${cost} btc and require game restart to see the change"
  	 	 	 	},
  	 	 	 	"input": {
@@ -1581,14 +1581,14 @@
  	 	 	 	 	 	 	 	"minLength",
  	 	 	 	 	 	 	 	"maxLength"
  	 	 	 	 	 	 	],
- 	 	 	 	 	 	 	"trans": "Ім'я рангу повинно бути між символами ${minLength} та ${maxLength}",
+ 	 	 	 	 	 	 	"trans": "Назва рангу має містити від ${minLength} до ${maxLength} символів",
  	 	 	 	 	 	 	"eng": "Rank name must be between ${minLength} and ${maxLength} characters"
  	 	 	 	 	 	}
  	 	 	 	 	}
  	 	 	 	},
  	 	 	 	"button": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Присвоювати",
+ 	 	 	 	 	 	"trans": "Призначити",
  	 	 	 	 	 	"eng": "Assign"
  	 	 	 	 	}
  	 	 	 	}
@@ -1648,7 +1648,7 @@
  	 	},
  	 	"captcha": {
  	 	 	"title": {
- 	 	 	 	"trans": "Введіть системний пароль",
+ 	 	 	 	"trans": "Введіть системний пароль, щоб продовжити",
  	 	 	 	"eng": "Enter system passcode to proceed"
  	 	 	}
  	 	},
@@ -1671,7 +1671,7 @@
  	 	 	 	 	"eng": "Dungeons"
  	 	 	 	},
  	 	 	 	"des": {
- 	 	 	 	 	"trans": "В підземеллях, ваше здоров'я не буе відновлено після кожної битви, і вороги будуть сильнішими, але ви отримаєте більшу винагороду і досвід",
+ 	 	 	 	 	"trans": "В підземеллях, ваше здоров'я не буде відновлено після кожної битви, і вороги будуть сильнішими, але ви отримаєте більшу винагороду і більше досвіду",
  	 	 	 	 	"eng": "In dungeons, you will not heal after each fight, and enemies are stronger, but there are more exp and loots"
  	 	 	 	}
  	 	 	},
@@ -1686,7 +1686,7 @@
  	 	 	 	}
  	 	 	},
  	 	 	"noHealingPrompt": {
- 	 	 	 	"trans": "Спробуйте спочатку придбати медикаменти",
+ 	 	 	 	"trans": "Може спочатку придбаєш медикаменти?",
  	 	 	 	"eng": "Maybe buy some healing item first?",
  	 	 	 	"des": {
  	 	 	 	 	"trans": "Схоже, у вас немає з собою препарату Біль-геть. Ви можете його придбати в Тріноки-марті перш ніж спускатись до підземель, адже ваше здоров'я не відновлюватиметься після кожного бою",
@@ -1704,13 +1704,13 @@
  	 	},
  	 	"rewardActionConfirmModal": {
  	 	 	"captcha": {
- 	 	 	 	"trans": "Перетягніть всі піктограми процесів у червоне поле повністю, щоб ініціювати завдання",
+ 	 	 	 	"trans": "Перетягніть значки всіх процесів у червоне поле повністю, щоб розпочати завдання",
  	 	 	 	"eng": "Drag all processes icons into to the red box entirely to initiate the task"
  	 	 	}
  	 	},
  	 	"confirmModal": {
  	 	 	"defaultConfirm": {
- 	 	 	 	"trans": "Підтверджувати",
+ 	 	 	 	"trans": "Підтвердити",
  	 	 	 	"eng": "Confirm"
  	 	 	}
  	 	},
@@ -1736,21 +1736,21 @@
  	 	 	 	},
  	 	 	 	"selectConfirm": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Оберіть Емблему",
+ 	 	 	 	 	 	"trans": "Обрати емблему?",
  	 	 	 	 	 	"eng": "Select Emblem?"
  	 	 	 	 	}
  	 	 	 	}
  	 	 	},
  	 	 	"donationTiers": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Ранги Донації",
+ 	 	 	 	 	"trans": "Рівні пожертвувань",
  	 	 	 	 	"eng": "Donation Tiers"
  	 	 	 	},
  	 	 	 	"expire": {
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"date"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Закінчується в ${date}",
+ 	 	 	 	 	"trans": "Закінчується ${date}",
  	 	 	 	 	"eng": "Expires at ${date}"
  	 	 	 	}
  	 	 	}
@@ -1783,7 +1783,7 @@
  	 	 	 	"eng": "Welcome to"
  	 	 	},
  	 	 	"welcomeMsg": {
- 	 	 	 	"trans": "найкращої текстової mmorpg",
+ 	 	 	 	"trans": "найкращої текстової MMORPG",
  	 	 	 	"eng": "the best text-based mmorpg"
  	 	 	},
  	 	 	"hasRefererCheckbox": {
@@ -1838,11 +1838,11 @@
  	 	 	 	 	"eng": "set character name to \"${name}\"?"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Ви не можете змінити це у майбутньому",
+ 	 	 	 	 	"trans": "Ви не зможете змінити цього у майбутньому",
  	 	 	 	 	"eng": "You cannot change this in the future"
  	 	 	 	},
  	 	 	 	"confirmButton": {
- 	 	 	 	 	"trans": "Я впевнений",
+ 	 	 	 	 	"trans": "Я впевнений!",
  	 	 	 	 	"eng": "I am sure"
  	 	 	 	}
  	 	 	}
@@ -1877,7 +1877,7 @@
  	 	},
  	 	"dailyReward": {
  	 	 	"nextLoginWindow": {
- 	 	 	 	"trans": "Наступний період логіну",
+ 	 	 	 	"trans": "Наступний період входу",
  	 	 	 	"eng": "Next Login Period"
  	 	 	},
  	 	 	"day": {
@@ -1954,24 +1954,24 @@
  	 	 	 	 	"eng": "Core not found"
  	 	 	 	},
  	 	 	 	"subTitle": {
- 	 	 	 	 	"trans": "Будь ласка, вставте калібрувальне ядро",
+ 	 	 	 	 	"trans": "Будь ласка, вставте Калібрувальне Ядро",
  	 	 	 	 	"eng": "Please insert Calibration Core"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Вам потрібно вставити калібрувальне ядро для оновлення обладнання.",
+ 	 	 	 	 	"trans": "Вам потрібно вставити Калібрувальне Ядро для оновлення обладнання.",
  	 	 	 	 	"eng": "You need to insert Calibration Core to upgrade your equipment."
  	 	 	 	},
  	 	 	 	"noCore": {
- 	 	 	 	 	"trans": "У вас не є ядро калібрування",
+ 	 	 	 	 	"trans": "У вас немає Калібрувального Ядра",
  	 	 	 	 	"eng": "You don\\'t have any Calibration Core"
  	 	 	 	}
  	 	 	},
  	 	 	"activate": {
- 	 	 	 	"trans": "Вставити ядро",
+ 	 	 	 	"trans": "Вставити Ядро",
  	 	 	 	"eng": "Insert Core"
  	 	 	},
  	 	 	"activateDescription": {
- 	 	 	 	"trans": "Калібрувальне ядро необхідне для калібрування обладнання",
+ 	 	 	 	"trans": "Калібрувальне Ядро необхідне для калібрування обладнання",
  	 	 	 	"eng": "A Calibration Core is required to calibrate equipment"
  	 	 	},
  	 	 	"activating": {
@@ -1990,12 +1990,12 @@
  	 	 	 	 	"eng": "equipment not found"
  	 	 	 	},
  	 	 	 	"subTitle": {
- 	 	 	 	 	"trans": "Виберіть обладнання, щоб продовжити",
+ 	 	 	 	 	"trans": "Оберіть обладнання, щоб продовжити",
  	 	 	 	 	"eng": "Select an equipment to continue"
  	 	 	 	}
  	 	 	},
  	 	 	"selectEquipmentTitle": {
- 	 	 	 	"trans": "Виберіть річ для калібрування",
+ 	 	 	 	"trans": "Оберіть річ для калібрування",
  	 	 	 	"eng": "Please select an item to calibrate"
  	 	 	},
  	 	 	"upgradeButton": {
@@ -2009,7 +2009,7 @@
  	 	 	 	"eng": "Cyberpunk Text-based MMORPG"
  	 	 	},
  	 	 	"description1": {
- 	 	 	 	"trans": "CyberCode Online є онлайн грою. Обліковий запис необхідний для збереження ігрових даних.",
+ 	 	 	 	"trans": "CyberCode Online - це онлайн гра, обліковий запис необхідний для збереження ігрових даних та вашого прогресу.",
  	 	 	 	"eng": "CyberCode Online is an online game, an account is needed to store game data."
  	 	 	},
  	 	 	"description2": {
@@ -2017,7 +2017,7 @@
  	 	 	 	"eng": "please register or login with existing account"
  	 	 	},
  	 	 	"asusDescription": {
- 	 	 	 	"trans": "ASUS PHONE (ZENFONE, ROG) має помилку при натисканні на екран. Якщо у вас виникла ця проблема, будь ласка, спробуйте вимкнути і ввімкнути екран, або згорніть цю програму, і відкрийте знову. Це має виправити проблему :)",
+ 	 	 	 	"trans": "Телефони ASUS (Zenfone, ROG) містять помилку при натисканні на екран. Якщо у вас виникла ця проблема, будь ласка, спробуйте вимкнути і ввімкнути екран, або згорніть гру та відкрийте її знову. Це повинно виправити помилку :)",
  	 	 	 	"eng": "ASUS phone (Zenfone, ROG) has bug with screen being not clickable, in the case, please try turning your screen off and on again, or put this app to background and resume it again. this should fix the issue :)"
  	 	 	}
  	 	},
@@ -2027,11 +2027,11 @@
  	 	 	 	"eng": "Item Inbox"
  	 	 	},
  	 	 	"descriptionV2": {
- 	 	 	 	"trans": "Тут тут будуть автоматично переміщені до вашого інвентарю, як тільки у вас буде достатньо місця.",
+ 	 	 	 	"trans": "Це предмети будуть автоматично переміщені до вашого інвентарю, коли у вас буде достатньо місця.",
  	 	 	 	"eng": "Items here will be automatically moved to your inventory once you have enough space."
  	 	 	},
  	 	 	"descriptionV3": {
- 	 	 	 	"trans": "Лише частина повного списку відображатиметься, якщо у вас є занадто багато елементів у папці \"Вхідні\".",
+ 	 	 	 	"trans": "Якщо у вашій скриньці забагато предметів, відображатиметься лише частина повного списку.",
  	 	 	 	"eng": "Only part of the full list will be displayed if you have too many items in your inbox."
  	 	 	},
  	 	 	"expiryDisplay": {
@@ -2046,11 +2046,11 @@
  	 	 	 	"eng": "There is no item in your item inbox"
  	 	 	},
  	 	 	"tooManyItems": {
- 	 	 	 	"trans": "У вашій скриньці може бути більше елементів, але у вас є занадто багато предметів у папці \"Вхідні\", щоб відобразити їх усіх.",
+ 	 	 	 	"trans": "Ваша скринька може містити більше елементів, але у вас занадто багато предметів, щоб відобразити їх усіх.",
  	 	 	 	"eng": "There might be more items in your inbox, but you have too many items in your inbox to display them all."
  	 	 	},
  	 	 	"getAllItems": {
- 	 	 	 	"trans": "Отримати всі",
+ 	 	 	 	"trans": "Отримати всі предмети",
  	 	 	 	"eng": "Get All Items"
  	 	 	}
  	 	},
@@ -2060,11 +2060,11 @@
  	 	 	 	"eng": "Links"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Тут ви можете знайти всі наші посилання в соціальних мережах, приходьте та зв’язатися з дивовижною спільнотою!",
+ 	 	 	 	"trans": "Тут ви можете знайти всі наші посилання в соціальних мережах, приходьте та спілкуйтеся з чудовою спільнотою!",
  	 	 	 	"eng": "Here you can find all our social media links, come and connect with the amazing community!"
  	 	 	},
  	 	 	"reportBug": {
- 	 	 	 	"trans": "Повідомте про помилку",
+ 	 	 	 	"trans": "Повідомити про помилку",
  	 	 	 	"eng": "Report a bug"
  	 	 	}
  	 	},
@@ -2081,7 +2081,7 @@
  	 	 	 	 	"eng": "Nearby Enemies"
  	 	 	 	},
  	 	 	 	"desc": {
- 	 	 	 	 	"trans": "Шукати ворогів на вулицях поблизу. Вороги за межами підземель слабкіші, і їх легше перемогти, але вони дають менше досвіду",
+ 	 	 	 	 	"trans": "Сканує найближчих ворогів на вулиці, вороги за межами підземель слабші, і їх легше перемогти. Однак перемога над ними дає менше досвіду",
  	 	 	 	 	"eng": "Scans for nearby enemies on the street, enemies outside dungeons are weaker and easier to defeat. However they also drop less exp"
  	 	 	 	}
  	 	 	}
@@ -2105,7 +2105,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"level"
  	 	 	 	],
- 	 	 	 	"trans": "Вам потрібно бути принаймні рівнем ${level}, щоб поспілкуватися",
+ 	 	 	 	"trans": "Щоб спілкуватися в чаті, потрібно досягти рівня не нижче ${level}",
  	 	 	 	"eng": "You need to be at least level ${level} to chat"
  	 	 	}
  	 	},
@@ -2119,7 +2119,7 @@
  	 	 	 	"eng": "gather the caches from enemies and dungeons to print your new weapons and armor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Клацніть тут, щоб дізнатися більше про молекулярний принтер",
+ 	 	 	 	"trans": "Клацніть тут, щоб дізнатися більше про Молекулярний Принтер",
  	 	 	 	"eng": "Click here to learn more about the Molecular Printer"
  	 	 	}
  	 	},
@@ -2137,7 +2137,7 @@
  	 	},
  	 	"npcSellPage": {
  	 	 	"autoSell": {
- 	 	 	 	"trans": "авто-продати",
+ 	 	 	 	"trans": "Авто Продаж",
  	 	 	 	"eng": "Auto Sell"
  	 	 	}
  	 	},
@@ -2147,11 +2147,11 @@
  	 	 	 	"eng": "remove"
  	 	 	},
  	 	 	"notIdle": {
- 	 	 	 	"trans": "Ви повинні бути бездіяльні, щоб зробити це",
+ 	 	 	 	"trans": "Ви повинні бути неактивні, щоб виконати цю дію",
  	 	 	 	"eng": "You must be idle to do this action"
  	 	 	},
  	 	 	"noItem": {
- 	 	 	 	"trans": "У вас у поточному не є товар у продажу",
+ 	 	 	 	"trans": "Зараз у вас немає жодного товару на продаж",
  	 	 	 	"eng": " You current don't have any item on sale"
  	 	 	}
  	 	},
@@ -2203,7 +2203,7 @@
  	 	 	"deleteAccount": {
  	 	 	 	"modal": {
  	 	 	 	 	"title": {
- 	 	 	 	 	 	"trans": "Ви впевнені, що хочете видалити свій обліковий запис? Всі ігрові дані буде безповоротно видалено.",
+ 	 	 	 	 	 	"trans": "Ви впевнені, що хочете видалити свій обліковий запис? Це незворотно, уся інформація облікового запису буде видалена.",
  	 	 	 	 	 	"eng": "Are you sure you want to delete your account? This is irreversible, all account information will be removed."
  	 	 	 	 	}
  	 	 	 	}
@@ -2211,7 +2211,7 @@
  	 	},
  	 	"statsPage": {
  	 	 	"quitGang": {
- 	 	 	 	"trans": "Вийти з ватаги",
+ 	 	 	 	"trans": "Вийти з банди",
  	 	 	 	"eng": "Quit Gang"
  	 	 	},
  	 	 	"logout": {
@@ -2237,7 +2237,7 @@
  	 	 	 	"eng": "equipment"
  	 	 	},
  	 	 	"enemyGangsAndMark": {
- 	 	 	 	"trans": "Ворожі ватаги та емблеми",
+ 	 	 	 	"trans": "Ворожі банди та емблеми",
  	 	 	 	"eng": "Enemy Gangs and Equipment Marks"
  	 	 	},
  	 	 	"timeSkip": {
@@ -2277,7 +2277,7 @@
  	 	 	 	"eng": "locations"
  	 	 	},
  	 	 	"quests": {
- 	 	 	 	"trans": "квести",
+ 	 	 	 	"trans": "завдання",
  	 	 	 	"eng": "quests"
  	 	 	},
  	 	 	"resources": {
@@ -2292,24 +2292,24 @@
  	 	"unlockContainerPage": {
  	 	 	"selectContainerModal": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Виберіть контейнер для розблокування",
+ 	 	 	 	 	"trans": "Будь ласка, виберіть контейнер для розблокування",
  	 	 	 	 	"eng": "Please select an container to unlock"
  	 	 	 	}
  	 	 	},
  	 	 	"title": {
- 	 	 	 	"trans": "Розблокувати контейнер",
+ 	 	 	 	"trans": "Розблокувати Контейнер",
  	 	 	 	"eng": "Unlock Container"
  	 	 	},
  	 	 	"selectContainer": {
  	 	 	 	"subTitle": {
- 	 	 	 	 	"trans": "Виберіть контейнер для розблокування",
+ 	 	 	 	 	"trans": "Будь ласка, виберіть контейнер для розблокування",
  	 	 	 	 	"eng": "Please select an container to unlock"
  	 	 	 	},
  	 	 	 	"title": {
  	 	 	 	 	"trans": "Контейнер",
  	 	 	 	 	"eng": "Container"
  	 	 	 	},
- 	 	 	 	"trans": "Виберіть контейнер",
+ 	 	 	 	"trans": "Виберіть Контейнер",
  	 	 	 	"eng": "Select Container"
  	 	 	},
  	 	 	"hint": {
@@ -2325,7 +2325,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"itemName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Отримайте до 2% (0,5% за легендарний контейнер) Додатковий шанс отримати кеш епічного рівня під час розблокування заколотного легендарного контейнера, активуючи ${itemName}",
+ 	 	 	 	 	"trans": "Отримайте до 2% (0.5% за Легендарний Контейнер) додаткового шансу отримати кеш епічного рівня, коли розблокуєте Заблокований Легендарний Контейнер, активувавши ${itemName}",
  	 	 	 	 	"eng": "Receive up to 2% (0.5% per Legendary Container) additional chance to get epic tier cache when unlocking Locked Legendary Container by activating ${itemName}"
  	 	 	 	},
  	 	 	 	"button": {
@@ -2338,14 +2338,14 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"itemName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "${itemName} активовано",
+ 	 	 	 	 	"trans": "${itemName} Активовано",
  	 	 	 	 	"eng": "${itemName} Activated"
  	 	 	 	},
  	 	 	 	"description": {
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"itemName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "${itemName} зараз активний, розблокуйте легендарний контейнер зараз, щоб мати 0,5% додаткових шансів для епічного рівня рівня на легендарний контейнер",
+ 	 	 	 	 	"trans": "${itemName} тепер активний, розблокуйте Легендарний Контейнер зараз, щоб мати 0.5% додаткового шансу отримати обладнання рівня EPIC за кожен Легендарний Контейнер",
  	 	 	 	 	"eng": "${itemName} is now active, unlock Legendary Container now to have 0.5% additional chance for EPIC tier equipment per Legendary Container"
  	 	 	 	}
  	 	 	},
@@ -2360,7 +2360,7 @@
  	 	 	"vars": [
  	 	 	 	"time"
  	 	 	],
- 	 	 	"trans": "Доступно ще раз у ${time}",
+ 	 	 	"trans": "Знову доступний через ${time}",
  	 	 	"eng": "Available again in ${time}"
  	 	},
  	 	"free": {
@@ -2375,7 +2375,7 @@
  	 	},
  	 	"skip": {
  	 	 	"name": {
- 	 	 	 	"trans": "Пропустити пакет постачання",
+ 	 	 	 	"trans": "Пропустити набір поставок",
  	 	 	 	"eng": "Skip supply bundle"
  	 	 	}
  	 	},
@@ -2424,7 +2424,7 @@
  	 	 	},
  	 	 	"once": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Раз",
+ 	 	 	 	 	"trans": "Один раз",
  	 	 	 	 	"eng": "Once"
  	 	 	 	},
  	 	 	 	"description": {
@@ -2440,15 +2440,15 @@
  	 	 	 	"vars": [
  	 	 	 	 	"current"
  	 	 	 	],
- 	 	 	 	"trans": "Exp Buff (наразі ${current}%)",
+ 	 	 	 	"trans": "Бафф Досвіду (Зараз ${current}%)",
  	 	 	 	"eng": "EXP Buff (Currently ${current}%)"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Збільшити приріст EXP на 80% протягом 20 хвилин",
+ 	 	 	 	"trans": "Збільште приріст Досвіду на 80% протягом 20 хвилин",
  	 	 	 	"eng": "Increase your EXP gain by 80% for 20 minutes"
  	 	 	},
  	 	 	"button": {
- 	 	 	 	"trans": "Активізувати",
+ 	 	 	 	"trans": "Активувати",
  	 	 	 	"eng": "Activate"
  	 	 	}
  	 	}
@@ -2479,7 +2479,7 @@
  	 	 	"eng": "send"
  	 	},
  	 	"requires": {
- 	 	 	"trans": "Потребує",
+ 	 	 	"trans": "Вимагає",
  	 	 	"eng": "Requires"
  	 	},
  	 	"durability": {
@@ -2499,15 +2499,15 @@
  	 	 	"eng": "level"
  	 	},
  	 	"notTradable": {
- 	 	 	"trans": "не до продажу",
+ 	 	 	"trans": "не для продажу",
  	 	 	"eng": "not tradable"
  	 	},
  	 	"amount": {
- 	 	 	"trans": "Кількість",
+ 	 	 	"trans": "кількість",
  	 	 	"eng": "amount"
  	 	},
  	 	"itemUpgradeCapacity": {
- 	 	 	"trans": "Рівень калібрування",
+ 	 	 	"trans": "Рівень Калібрування",
  	 	 	"eng": "Calibration Capacity"
  	 	},
  	 	"name": {
@@ -2523,11 +2523,11 @@
  	 	 	"eng": "Rank"
  	 	},
  	 	"quickSlot": {
- 	 	 	"trans": "Швидкий слот",
+ 	 	 	"trans": "Швидкий Слот",
  	 	 	"eng": "Quick Slot"
  	 	},
  	 	"receives": {
- 	 	 	"trans": "Одержати",
+ 	 	 	"trans": "Отримує",
  	 	 	"eng": "Receives"
  	 	},
  	 	"inputPlaceholder": {
@@ -2567,7 +2567,7 @@
  	 	 	"eng": "okay"
  	 	},
  	 	"close": {
- 	 	 	"trans": "закрити",
+ 	 	 	"trans": "Закрити",
  	 	 	"eng": "Close"
  	 	},
  	 	"characterNameError": {
@@ -2596,7 +2596,7 @@
  	 	 	"eng": "${time} ago"
  	 	},
  	 	"systemStandby": {
- 	 	 	"trans": "Очікування",
+ 	 	 	"trans": "Режим очікування системи",
  	 	 	"eng": "System standby"
  	 	},
  	 	"password": {
@@ -2611,11 +2611,11 @@
  	 	 	 	"eng": "Player contributed content"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Ви також можете докластися до легенд речей, шляхом редагування файлу конфігурації на нашій сторінці Github.",
+ 	 	 	 	"trans": "Ви також можете зробити свій внесок у легенди предметів, відредагувавши файл конфігурації на нашій сторінці GitHub.",
  	 	 	 	"eng": "You can contribute to the lore of items too by editing the config file in our GitHub page."
  	 	 	},
  	 	 	"confirm": {
- 	 	 	 	"trans": "До github",
+ 	 	 	 	"trans": "Перейти до GitHub",
  	 	 	 	"eng": "Go to GitHub"
  	 	 	},
  	 	 	"cancel": {
@@ -2627,18 +2627,18 @@
  	"battleUI": {
  	 	"quickSlotModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "Виберіть елемент, щоб прив’язати до швидкого слота",
+ 	 	 	 	"trans": "Оберіть елемент для прив’язки до швидкого слота",
  	 	 	 	"eng": "Select an item to bind to quick slot"
  	 	 	}
  	 	}
  	},
  	"cost": {
  	 	"requireGang": {
- 	 	 	"trans": "Ви повинні бути у ватазі",
+ 	 	 	"trans": "Ви повинні бути членом банди",
  	 	 	"eng": "Requires you to be in a gang"
  	 	},
  	 	"requireTopGang": {
- 	 	 	"trans": "Ваша ватага має бути однією з 2х топ ватаг в Таблиці Лідерів впливу",
+ 	 	 	"trans": "Ви повинні входити до топ 2-х найкращих банд серед Лідерів Впливу",
  	 	 	"eng": "Requires you to be in the Top 2 Gangs on the Occupation Leaderboard"
  	 	}
  	},
@@ -2679,7 +2679,7 @@
  	 	},
  	 	"healthRegen": {
  	 	 	"name": {
- 	 	 	 	"trans": "відновлення здоров'я",
+ 	 	 	 	"trans": "Відновлення здоров'я",
  	 	 	 	"eng": "Health regen"
  	 	 	},
  	 	 	"description": {
@@ -2773,7 +2773,7 @@
  	 	 	 	"eng": "Pocket"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Підвищує розмір інвентару",
+ 	 	 	 	"trans": "Збільшує розмір інвентарю",
  	 	 	 	"eng": "Increases inventory capacity"
  	 	 	}
  	 	},
@@ -2819,7 +2819,7 @@
  	 	},
  	 	"healMultiplier": {
  	 	 	"name": {
- 	 	 	 	"trans": "Множник Зцілення",
+ 	 	 	 	"trans": "Множник зцілення",
  	 	 	 	"eng": "Healing multiplier"
  	 	 	},
  	 	 	"description": {
@@ -2849,7 +2849,7 @@
  	 	},
  	 	"btcMultiplier": {
  	 	 	"name": {
- 	 	 	 	"trans": "Множник Біткойна",
+ 	 	 	 	"trans": "Множник біткойна",
  	 	 	 	"eng": "BTC multiplier"
  	 	 	},
  	 	 	"description": {
@@ -2859,11 +2859,11 @@
  	 	},
  	 	"upgradeChance": {
  	 	 	"name": {
- 	 	 	 	"trans": "Ризик калібрування",
+ 	 	 	 	"trans": "Шанс Калібрування",
  	 	 	 	"eng": "Calibration Chance"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Знижує ризик руйнівної невдачі при калібруванні предметів",
+ 	 	 	 	"trans": "Знижує ризик руйнівної невдачі при Калібруванні предметів",
  	 	 	 	"eng": "Reduces chance of destructive failure when calibrating items"
  	 	 	}
  	 	},
@@ -2885,7 +2885,7 @@
  	 	},
  	 	"rngInterferer": {
  	 	 	"description": {
- 	 	 	 	"trans": "Додатковий шанс отримати епічні матеріали з контейнерів",
+ 	 	 	 	"trans": "Додатковий шанс отримати Епічні матеріали з Контейнерів",
  	 	 	 	"eng": "Additional epic drop chance from containers"
  	 	 	}
  	 	},
@@ -2901,7 +2901,7 @@
  	 	 	 	"eng": "Animals Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з ватаги Тварин",
+ 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з банди Тварин",
  	 	 	 	"eng": "Increases damage to Enemies of Animals gang"
  	 	 	}
  	 	},
@@ -2911,7 +2911,7 @@
  	 	 	 	"eng": "Voodoo Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з ватаги Хлопчаків Вуду",
+ 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з банди Хлопчаків Вуду",
  	 	 	 	"eng": "Increases damage to Enemies of Voodoo Boys gang"
  	 	 	}
  	 	},
@@ -2921,7 +2921,7 @@
  	 	 	 	"eng": "Scavengers Nemesis"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з ватаги Падальників",
+ 	 	 	 	"trans": "Збільшує збиток, завданий ворогам з банди Падальників",
  	 	 	 	"eng": "Increases damage to Enemies of Scavengers gang"
  	 	 	}
  	 	},
@@ -2931,7 +2931,7 @@
  	 	 	 	"eng": "Lethal"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Вороги з ватаги Падальників завдають вам вищий збиток",
+ 	 	 	 	"trans": "Вороги з банди Падальників завдають вам вищий збиток",
  	 	 	 	"eng": "Enemies of Scavengers gang deals increased damage to you"
  	 	 	}
  	 	},
@@ -2941,7 +2941,7 @@
  	 	 	 	"eng": "Disruptor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Вороги з ватаги Тварин завдають вам вищий збиток",
+ 	 	 	 	"trans": "Вороги з банди Тварин завдають вам вищий збиток",
  	 	 	 	"eng": "Enemies of Animals gang deals increased damage to you"
  	 	 	}
  	 	},
@@ -2951,7 +2951,7 @@
  	 	 	 	"eng": "Makeshift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Вороги з ватаги Хлопчаки Вуду завдають вам вищий збиток",
+ 	 	 	 	"trans": "Вороги з банди Хлопчаки Вуду завдають вам вищий збиток",
  	 	 	 	"eng": "Enemies of Voodoo Boys gang deals increased damage to you"
  	 	 	}
  	 	}
@@ -2962,7 +2962,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"diff"
  	 	 	 	],
- 	 	 	 	"trans": "Неточний час пристрою (різниця у часі: ${diff}). Щоб забезпечити правильне відображення ігор, таких як Buff, Time Skip та AFK. Будь ласка, синхронізуйте час пристрою з мережею та переконайтеся, що ваша часова зона встановлена правильно",
+ 	 	 	 	"trans": "Неточний час пристрою (різниця в часі: ${diff}). щоб забезпечити правильне відображення таких функцій гри, як бафф, пропуск часу та завдання AFK. Будь ласка, синхронізуйте час пристрою з мережею та переконайтеся, що часовий пояс налаштовано правильно",
  	 	 	 	"eng": "Inaccurate device time (time difference: ${diff}). to ensure game features such as buff, time skip and AFK Task display correctly. Please sync your device time with network and ensure your time-zone is set correctly"
  	 	 	}
  	 	},
@@ -2978,7 +2978,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"days"
  	 	 	 	],
- 	 	 	 	"trans": "${days} дні",
+ 	 	 	 	"trans": "${days} днів",
  	 	 	 	"eng": "${days} days"
  	 	 	},
  	 	 	"hours": {
@@ -2992,14 +2992,14 @@
  	 	 	 	"vars": [
  	 	 	 	 	"minutes"
  	 	 	 	],
- 	 	 	 	"trans": "${minutes} хвилини",
+ 	 	 	 	"trans": "${minutes} хвилин",
  	 	 	 	"eng": "${minutes} minutes"
  	 	 	},
  	 	 	"seconds": {
  	 	 	 	"vars": [
  	 	 	 	 	"seconds"
  	 	 	 	],
- 	 	 	 	"trans": "${seconds} секунди",
+ 	 	 	 	"trans": "${seconds} секунд",
  	 	 	 	"eng": "${seconds} seconds"
  	 	 	}
  	 	}
@@ -3031,42 +3031,42 @@
  	},
  	"reward": {
  	 	"unknown": {
- 	 	 	"trans": "Невідомі речі",
+ 	 	 	"trans": "Невідомі Предмети",
  	 	 	"eng": "Unknown Items"
  	 	},
  	 	"gangResource": {
  	 	 	"vars": [
  	 	 	 	"clanResource"
  	 	 	],
- 	 	 	"trans": "${clanResource} ресурс ватаги",
+ 	 	 	"trans": "${clanResource} ресурс банди",
  	 	 	"eng": "${clanResource} gang resource"
  	 	},
  	 	"gangExp": {
  	 	 	"vars": [
  	 	 	 	"clanExp"
  	 	 	],
- 	 	 	"trans": "${clanExp} досвід ватаги",
+ 	 	 	"trans": "${clanExp} досвід банди",
  	 	 	"eng": "${clanExp} gang exp"
  	 	},
  	 	"gangFunding": {
  	 	 	"vars": [
  	 	 	 	"clanMoney"
  	 	 	],
- 	 	 	"trans": "${clanMoney} кошти ватаги",
+ 	 	 	"trans": "${clanMoney} кошти банди",
  	 	 	"eng": "${clanMoney} gang funding"
  	 	},
  	 	"gangOccupationPoint": {
  	 	 	"vars": [
  	 	 	 	"clanOccupationPoint"
  	 	 	],
- 	 	 	"trans": "${clanOccupationPoint} керування контролем над містом",
+ 	 	 	"trans": "${clanOccupationPoint} контроль над містом",
  	 	 	"eng": "${clanOccupationPoint} Occupation Control"
  	 	},
  	 	"globalQuestPoint": {
  	 	 	"vars": [
  	 	 	 	"globalQuestPoint"
  	 	 	],
- 	 	 	"trans": "${globalQuestPoint} прогрес кібератаки Фортеці Даних Шангрі-ла",
+ 	 	 	"trans": "${globalQuestPoint} прогрес кібератаки на Фортецю Даних Шангрі-Ла",
  	 	 	"eng": "${globalQuestPoint} SL Data Fortress breach progress"
  	 	}
  	},
@@ -3075,7 +3075,7 @@
  	 	 	"vars": [
  	 	 	 	"item"
  	 	 	],
- 	 	 	"trans": "Недостатньо місця в кишені для ${item}",
+ 	 	 	"trans": "У вашому інвентарі недостатньо місця для ${item}",
  	 	 	"eng": "There is no enough space in your inventory for ${item}"
  	 	},
  	 	"takeAll": {
@@ -3083,16 +3083,16 @@
  	 	 	"eng": "Take all"
  	 	},
  	 	"discard": {
- 	 	 	"trans": "Видалити",
+ 	 	 	"trans": "Відмовитись",
  	 	 	"eng": "Discard"
  	 	},
  	 	"discardPrompt": {
  	 	 	"title": {
- 	 	 	 	"trans": "Ви впевнені, що хочете видалити?",
+ 	 	 	 	"trans": "Ви впевнені, що хочете відмовитись?",
  	 	 	 	"eng": "Are you sure you want to discard?"
  	 	 	},
  	 	 	"confirm": {
- 	 	 	 	"trans": "Видалити",
+ 	 	 	 	"trans": "Відмовитись",
  	 	 	 	"eng": "Discard"
  	 	 	},
  	 	 	"warning": {
@@ -3114,17 +3114,17 @@
  	 	 	 	"eng": "Newbie with benefit"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Вбийте кількох ворогів і отримайте повний набір предметів, щоб почати вашу подорож в Шангрі-ла",
+ 	 	 	 	"trans": "Вбийте кількох ворогів і отримайте повний набір предметів, щоб почати вашу подорож в Шангрі-Ла",
  	 	 	 	"eng": "Kill some enemies and get a full set of items for you to start your journey"
  	 	 	}
  	 	},
  	 	"newbie2": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Союзники і друзі",
+ 	 	 	 	"trans": "Союзники і Друзі",
  	 	 	 	"eng": "Allies and Friends"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Ласкаво просимо до CyberCode онлайн, \r\n         спілкування з людьми онлайн буде дуже корисним для виконання кооперативних завдань, \r\n         Сміливо запитуйте у інших гравців в чаті, якщо у вас є які-небудь питання :) \r\n         Але пам'ятайте, за спам в чаті, вас буде тимчасово приглушено модераторами.",
+ 	 	 	 	"trans": "Ласкаво просимо до CyberCode Online, \r\n         спілкування з людьми онлайн буде дуже корисним для виконання кооперативних завдань, \r\n         Сміливо запитуйте у інших гравців в чаті, якщо у вас є які-небудь питання :) \r\n         Але пам'ятайте, за спам в чаті, вас буде тимчасово приглушено модераторами.",
  	 	 	 	"eng": "Welcome to CyberCode Online,\r\n        making friends with people online will be very useful for you to complete co-op quests,\r\n        go ahead ask people online if you have got any questions :)\r\n        Remember, if you spam in the chat, you will be muted by moderators."
  	 	 	}
  	 	},
@@ -3134,17 +3134,17 @@
  	 	 	 	"eng": "Reach printing rank 3"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Рівень речей, які ви друкуєте зі схем визначається вашим рівнем друку,\r\n        підвищіть свій рівень друку, щоб виготовляти обладнання вищого рівня.\r\n        \r\n        Ви можете знайти Молекулярний 3Д принтер в [Центральній точці], використайте його, щоб надрукувати кілька схем і підвищити ваш рівень друку",
+ 	 	 	 	"trans": "Рівень речей, які ви друкуєте зі схем визначається вашим рівнем друку,\r\n        підвищте свій рівень друку, щоб виготовляти обладнання вищого рівня.\r\n        \r\n        Ви можете знайти Молекулярний 3D Принтер в [Центральній точці], використайте його, щоб надрукувати кілька схем і підвищити ваш рівень друку",
  	 	 	 	"eng": "The level of itemS you print with Caches are determined by your Printing Rank,\r\n        level up your Printing Rank so you can print higher level items.\r\n        \r\n        You can find Molecular 3D Printer at [Central Hub], use it to print some caches to level up your Printing Rank"
  	 	 	}
  	 	},
  	 	"newbie4": {
  	 	 	"displayName": {
- 	 	 	 	"trans": "Відкрити сейфи",
+ 	 	 	 	"trans": "Відкрити Сейфи",
  	 	 	 	"eng": "Open Crate"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Відкрийте 4 сейфи в підземеллі, щоб отримати їх солодкий вміст!",
+ 	 	 	 	"trans": "Відкрийте 4 сейфи в підземеллі, щоб отримати їх жаданий вміст!",
  	 	 	 	"eng": "Open 4 crates in dungeon to get them sweet loots!"
  	 	 	}
  	 	},
@@ -3154,7 +3154,7 @@
  	 	 	 	"eng": "Market merchant"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Ви можете продавати та купувати товари від гравців на ринку гравців, спробуйте виставити якусь річ на продаж на ринку гравців",
+ 	 	 	 	"trans": "Ви можете продавати та купувати товари від гравців на ринку, спробуйте виставити якусь річ на продаж на ринку",
  	 	 	 	"eng": "You can sell and purchase items from players in the player market, try it out by adding an item to the player market"
  	 	 	}
  	 	},
@@ -3170,7 +3170,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"level"
  	 	 	 	],
- 	 	 	 	"trans": "Рівень охоплення ${level} для спеціальних подарунків!",
+ 	 	 	 	"trans": "Досягніть рівня ${level} для особливих подарунків!",
  	 	 	 	"eng": "Reach level ${level} for special gifts!"
  	 	 	}
  	 	},
@@ -3255,37 +3255,37 @@
  	 	 	}
  	 	},
  	 	"abandonConfirm": {
- 	 	 	"trans": "Ви впевнені, що хочете відмовитися від цього квесту?",
+ 	 	 	"trans": "Ви впевнені, що хочете відмовитися від цього завдання?",
  	 	 	"eng": "Are you sure you want to abandon this quest?"
  	 	}
  	},
  	"priceTag": {
  	 	"free": {
- 	 	 	"trans": "Безкоштовний",
+ 	 	 	"trans": "БЕЗКОШТОВНО",
  	 	 	"eng": "FREE"
  	 	}
  	},
  	"sessionClosedScreen": {
  	 	"title": {
- 	 	 	"trans": "Ви увійшли на інший пристрій",
+ 	 	 	"trans": "Ви ввійшли в систему на іншому пристрої",
  	 	 	"eng": "You have logged in on another device"
  	 	},
  	 	"description": {
- 	 	 	"trans": "Якщо ви хочете продовжувати грати на цьому пристрої, натисніть «Повторно підключитися».",
+ 	 	 	"trans": "Якщо ви бажаєте продовжити гру на цьому пристрої, натисніть \"Повторно під'єднатись\".",
  	 	 	"eng": "If you wish to continue playing on this device, please click reconnect."
  	 	},
  	 	"restartApp": {
- 	 	 	"trans": "Знову підключитися",
+ 	 	 	"trans": "Повторно під'єднатись",
  	 	 	"eng": "Reconnect Now"
  	 	}
  	},
  	"slider": {
  	 	"min": {
- 	 	 	"trans": "Хв",
+ 	 	 	"trans": "Мінімум",
  	 	 	"eng": "Min"
  	 	},
  	 	"max": {
- 	 	 	"trans": "максимум",
+ 	 	 	"trans": "Максимум",
  	 	 	"eng": "max"
  	 	}
  	},
@@ -3307,7 +3307,7 @@
  	 	 	 	"eng": "Reduce time needed for action by 40%, stackable upto 80%"
  	 	 	},
  	 	 	"activate": {
- 	 	 	 	"trans": "Зменшіть зараз",
+ 	 	 	 	"trans": "зменшити зараз",
  	 	 	 	"eng": "reduce now"
  	 	 	}
  	 	},
@@ -3352,7 +3352,7 @@
  	},
  	"tutorial": {
  	 	"localCombatButton": {
- 	 	 	"trans": "Натисніть тут, щоб шукати ворогів на вулицях поблизу",
+ 	 	 	"trans": "Натисніть тут, щоб знайти ворогів на вулицях поблизу",
  	 	 	"eng": "Click here to scan for street enemies"
  	 	},
  	 	"localCombatTip": {
@@ -3368,7 +3368,7 @@
  	 	 	"eng": "Click 'TAKE ALL' to get all the loots"
  	 	},
  	 	"dungeonQuest": {
- 	 	 	"trans": "Натисніть \"Взяти квест\", щоб прийняти квест. Ви можете завершити або відмовитися від квесту в будь-який час",
+ 	 	 	"trans": "Натисніть \"ВЗЯТИ ЗАВДАННЯ\", щоб взяти завдання. Ви можете завершити або відмовитися від завдання в будь-який час",
  	 	 	"eng": "Click 'ACCEPT QUEST' to accept the quest, you may complete or abandon the quest at any time"
  	 	}
  	},
@@ -3532,11 +3532,11 @@
  	 	},
  	 	"paypal": {
  	 	 	"paypalBonusTitle": {
- 	 	 	 	"trans": "Всі покупки через PayPal надають 10% додаткових Юнітів! PayPal можна використати лише на веб-версії гри, просто ввійдіть через свій браузер.",
+ 	 	 	 	"trans": "Всі покупки через PayPal надають 10% додаткових Юнітів! PayPal можна використати лише через веб-версію гри, просто увійдіть через свій браузер.",
  	 	 	 	"eng": "All PayPal purchases grants 10% additional Units! You may use paypal only on website version, simply login with your browser."
  	 	 	},
  	 	 	"paypalBonus": {
- 	 	 	 	"trans": "Ви отримаєте додаткові 10% Юнітів з покупкою PayPal",
+ 	 	 	 	"trans": "Ви отримаєте додаткові 10% Юнітів з покупкою через PayPal",
  	 	 	 	"eng": "You will receive additional 10% more Units with paypal purchase"
  	 	 	}
  	 	},
@@ -3559,7 +3559,7 @@
  	 	 	"eng": "Member"
  	 	},
  	 	"donation2": {
- 	 	 	"trans": "Донор",
+ 	 	 	"trans": "Дародавець",
  	 	 	"eng": "Donator"
  	 	},
  	 	"donation3": {
@@ -3567,11 +3567,11 @@
  	 	 	"eng": "Elite"
  	 	},
  	 	"donation4": {
- 	 	 	"trans": "Легендарний",
+ 	 	 	"trans": "Легенда",
  	 	 	"eng": "Legendary"
  	 	},
  	 	"donation5": {
- 	 	 	"trans": "Кібернетична картопля",
+ 	 	 	"trans": "Кібер картопля",
  	 	 	"eng": "Cybernetic Potato"
  	 	},
  	 	"donation6": {
@@ -3587,7 +3587,7 @@
  	 	 	"eng": "Prestige"
  	 	},
  	 	"donation9": {
- 	 	 	"trans": "Престиж",
+ 	 	 	"trans": "КіберЗайка",
  	 	 	"eng": "CyberBunny"
  	 	},
  	 	"donation10": {
@@ -3595,19 +3595,19 @@
  	 	 	"eng": "Prestige"
  	 	},
  	 	"donation11": {
- 	 	 	"trans": "Кіберкітті",
+ 	 	 	"trans": "КіберКотик",
  	 	 	"eng": "CyberKitty"
  	 	},
  	 	"donation12": {
- 	 	 	"trans": "Кіберсанта",
+ 	 	 	"trans": "КіберСанта",
  	 	 	"eng": "CyberSanta"
  	 	},
  	 	"donation13": {
- 	 	 	"trans": "Кіберфрост",
+ 	 	 	"trans": "КіберФрост",
  	 	 	"eng": "CyberFrost"
  	 	},
  	 	"donation14": {
- 	 	 	"trans": "Кібердрагон",
+ 	 	 	"trans": "КіберДракон",
  	 	 	"eng": "Cyberdragon"
  	 	},
  	 	"donation15": {
@@ -3627,7 +3627,7 @@
  	 	"donation1": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Титул мецената \"Член\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Член\"",
  	 	 	 	 	"eng": "\"Member\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3643,7 +3643,7 @@
  	 	"donation2": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Титул мецената \"Донатор\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Дародавець\"",
  	 	 	 	 	"eng": "\"Donator\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3663,7 +3663,7 @@
  	 	"donation3": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Титул мецената \"Еліта\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Еліта\"",
  	 	 	 	 	"eng": "\"Elite\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3687,15 +3687,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Налаштування девізу ватаги",
+ 	 	 	 	 	"trans": "Налаштування девізу банди",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Налаштування зображення ватаги",
+ 	 	 	 	 	"trans": "Налаштування зображення банди",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "і більше у майбутніх оновленнях гри",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3703,7 +3703,7 @@
  	 	"donation4": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Титул мецената \"Легендарний\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Легенда\"",
  	 	 	 	 	"eng": "\"Legendary\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3727,15 +3727,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Налаштування девізу ватаги",
+ 	 	 	 	 	"trans": "Налаштування девізу банди",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Налаштування зображення ватаги",
+ 	 	 	 	 	"trans": "Налаштування зображення банди",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "і більше у майбутніх оновленнях гри",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3743,11 +3743,11 @@
  	 	"donation5": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Кібернетична картопля",
+ 	 	 	 	 	"trans": "Кібер картопля",
  	 	 	 	 	"eng": "Cybernetic Potato"
  	 	 	 	},
  	 	 	 	"2": {
- 	 	 	 	 	"trans": "Титул мецената \"кібернетична картопля\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Кібер картопля\"",
  	 	 	 	 	"eng": "\"Cybernetic Potato\" donation title"
  	 	 	 	},
  	 	 	 	"3": {
@@ -3775,23 +3775,23 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Налаштування девіз ватаги",
+ 	 	 	 	 	"trans": "Налаштування девіз банди",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"10": {
- 	 	 	 	 	"trans": "Налаштуйте зображення ватаги",
+ 	 	 	 	 	"trans": "Налаштуйте зображення банди",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"11": {
- 	 	 	 	 	"trans": "і більше у майбутніх оновленнях гри",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	},
  	 	 	 	"12": {
- 	 	 	 	 	"trans": "Чи я уже згадав, що ви можете бути кібернетичною картоплею?",
+ 	 	 	 	 	"trans": "Чи я вже згадував, що ви можете бути Кібер картоплею?",
  	 	 	 	 	"eng": "Did I mention you could be a Cybernetic Potato?"
  	 	 	 	},
  	 	 	 	"13": {
- 	 	 	 	 	"trans": "Безкоштовна картопляна емблема",
+ 	 	 	 	 	"trans": "Безкоштовна Картопляна емблема",
  	 	 	 	 	"eng": "Free Potato Emblem"
  	 	 	 	}
  	 	 	}
@@ -3799,7 +3799,7 @@
  	 	"donation6": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Титул мецената \"Престиж\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"Престиж\"",
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3823,15 +3823,15 @@
  	 	 	 	 	"eng": "Barcode decoration on profile"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "Налаштування девізу ватаги",
+ 	 	 	 	 	"trans": "Налаштування девізу банди",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "Налаштування зображення ватаги",
+ 	 	 	 	 	"trans": "Налаштування зображення банди",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "і більше у майбутніх оновленнях гри",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3839,7 +3839,7 @@
  	 	"donation7": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування",
+ 	 	 	 	 	"trans": "Назва пожертви \"Престиж\"",
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3871,7 +3871,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3879,7 +3879,7 @@
  	 	"donation8": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування",
+ 	 	 	 	 	"trans": "Назва пожертви \"Престиж\"",
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3911,7 +3911,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3919,7 +3919,7 @@
  	 	"donation9": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування",
+ 	 	 	 	 	"trans": "Назва пожертви \"КіберЗайка\"",
  	 	 	 	 	"eng": "\"CyberBunny\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3951,7 +3951,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3959,7 +3959,7 @@
  	 	"donation10": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування",
+ 	 	 	 	 	"trans": "Назва пожертви \"Престиж\"",
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -3991,7 +3991,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -3999,7 +3999,7 @@
  	 	"donation11": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертв \"Cyberkitty\"",
+ 	 	 	 	 	"trans": "Назва пожертв \"КіберКотик\"",
  	 	 	 	 	"eng": "\"CyberKitty\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -4031,7 +4031,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4039,7 +4039,7 @@
  	 	"donation12": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертви \"Кіберсанта\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"КіберСанта\"",
  	 	 	 	 	"eng": "\"CyberSanta\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -4071,7 +4071,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4079,7 +4079,7 @@
  	 	"donation13": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертви \"Cyberfrost\"",
+ 	 	 	 	 	"trans": "Назва пожертви \"КіберФрост\"",
  	 	 	 	 	"eng": "\"CyberFrost\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -4111,7 +4111,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4119,7 +4119,7 @@
  	 	"donation14": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування \"Cyberdragon\"",
+ 	 	 	 	 	"trans": "Назва пожертвування \"КіберДракон\"",
  	 	 	 	 	"eng": "\"Cyberdragon\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -4151,7 +4151,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4159,7 +4159,7 @@
  	 	"donation15": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "Назва пожертвування",
+ 	 	 	 	 	"trans": "Назва пожертви \"Престиж\"",
  	 	 	 	 	"eng": "\"Prestige\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
@@ -4191,7 +4191,7 @@
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "Більше майбутнього оновлення",
+ 	 	 	 	 	"trans": "І більше у майбутніх оновленнях гри",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -4204,7 +4204,7 @@
  	 	 	 	"eng": "Lethal"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "завдає більших збитків ватазі Тварин. збільшує збитки від ватаги Падальників.",
+ 	 	 	 	"trans": "завдає більших збитків банді Тварин. збільшує збитки від банди Падальників.",
  	 	 	 	"eng": "deals increased damage to Animals gang. receives increased damage from Scavengers gang."
  	 	 	}
  	 	},
@@ -4214,7 +4214,7 @@
  	 	 	 	"eng": "Disruptor"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "завдає більших збитків ватазі Хлопчаків Вуду. збільшує збитки від ватаги Тварин.",
+ 	 	 	 	"trans": "завдає більших збитків банді Хлопчаків Вуду. збільшує збитки від банди Тварин.",
  	 	 	 	"eng": "deals increased damage to Voodoo Boys gang. receives increased damage from Animals gang."
  	 	 	}
  	 	},
@@ -4224,7 +4224,7 @@
  	 	 	 	"eng": "Makeshift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "завдає більших збитків ватазі Падальників. збільшує збитки від ватаги Хлопчаків Вуду.",
+ 	 	 	 	"trans": "завдає більших збитків банді Падальників. збільшує збитки від банди Хлопчаків Вуду.",
  	 	 	 	"eng": "deals increased damage to Scavengers gang. receives increased damage from Voodoo Boys gang."
  	 	 	}
  	 	}
@@ -4235,7 +4235,7 @@
  	 	 	"eng": "primary weapon"
  	 	},
  	 	"secondaryWeapon": {
- 	 	 	"trans": "Спец зброя",
+ 	 	 	"trans": "спец зброя",
  	 	 	"eng": "special weapon"
  	 	},
  	 	"tertiaryWeapon": {
@@ -4266,7 +4266,7 @@
  	"item": {
  	 	"unknownEquipment": {
  	 	 	"name": {
- 	 	 	 	"trans": "Невідоме обладнання",
+ 	 	 	 	"trans": "Невідоме Обладнання",
  	 	 	 	"eng": "Unknown Equipment"
  	 	 	}
  	 	},
@@ -4717,7 +4717,7 @@
  	 	 	 	"eng": "Gang Invasion Order Transmitter"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Простий передавач, який можна під'єднати до зашифрованого каналу вашої ватаги, і видати наказ на вторгнення.\r\n        Цей пристрій необхідний для активації Підземель ватаги",
+ 	 	 	 	"trans": "Простий передавач, який можна під'єднати до зашифрованого каналу вашої банди, і видати наказ на вторгнення.\r\n        Цей пристрій необхідний для активації Підземель банди",
  	 	 	 	"eng": "A simple transmitter device that can be bind to your gang encrypted channel and give out invasion order.\r\n        This item is required to activate Gang Dungeons"
  	 	 	}
  	 	},
@@ -4733,11 +4733,11 @@
  	 	},
  	 	"clanExp": {
  	 	 	"name": {
- 	 	 	 	"trans": "Зашифрований уламок пам'яті ватаги",
+ 	 	 	 	"trans": "Зашифрований уламок пам'яті банди",
  	 	 	 	"eng": "encrypted gang memory shard"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Уламок пам'яті містить зашифровані таємниці ватаги. \r\n        Розшифруйте пам'ять у штабі ватаги, щоб отримати цінну інформацію (ви повинні належати до ватаги).",
+ 	 	 	 	"trans": "Уламок пам'яті містить зашифровані таємниці банди. \r\n        Розшифруйте пам'ять у штабі банди, щоб отримати цінну інформацію (ви повинні належати до банди).",
  	 	 	 	"eng": "A memory shard contains encrypted gang secrets, \r\n        decrypt this in your gang headquarters to gain useful intel (requires to be in a gang)"
  	 	 	}
  	 	},
@@ -4796,7 +4796,7 @@
  	 	 	 	"eng": "Calibration AI Shard (50%) [EVENT]"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Містить фрагменти передового AI, призначеного для допомоги при оновленні обладнання.\r\n        При використанні, шанс руйнівної невдачі знижується на 50% на 5 хвилин. Це дає баф тільки вам.\r\n        Ви можете калібрувати речі у штабі ватаги. Спочатку, ви повинні створити, або приєднатись до ватаги.",
+ 	 	 	 	"trans": "Містить фрагменти передового AI, призначеного для допомоги при оновленні обладнання.\r\n        При використанні, шанс руйнівної невдачі знижується на 50% на 5 хвилин. Це дає баф тільки вам.\r\n        Ви можете калібрувати речі у штабі банди. Спочатку, ви повинні створити, або приєднатись до банди.",
  	 	 	 	"eng": "Contains fragments of advance AI designed to assist with upgrading equipments.\r\n        When used, decreases the chance of destructive failure by 50% for 5 minutes. this only affect yourself.\r\n        You can calibrate items in your Gang Headquarters, you must join or start a gang first."
  	 	 	}
  	 	},
@@ -4951,7 +4951,7 @@
  	 	 	 	"eng": "Protocol Breach Shard"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Уламок, який містить передові експлойти. \r\n         Використовується для порушення систем, таких як фортеця даних Шангрі-ла",
+ 	 	 	 	"trans": "Уламок, який містить передові експлойти. \r\n         Використовується для порушення систем, таких як фортеця даних Шангрі-Ла",
  	 	 	 	"eng": "A shard that contains advance exploits. \r\n        Can be used to breach systems such as Shangri-la Data Fortress"
  	 	 	}
  	 	},
@@ -5130,7 +5130,7 @@
  	 	}
  	},
  	"foodUseVerb": {
- 	 	"trans": "Споживати",
+ 	 	"trans": "Спожити",
  	 	"eng": "Consume"
  	},
  	"levelType": {
@@ -5160,13 +5160,13 @@
  	 	},
  	 	"scavenge": {
  	 	 	"name": {
- 	 	 	 	"trans": "Навичка шпортання",
+ 	 	 	 	"trans": "навичка шпортання",
  	 	 	 	"eng": "scavenge skill"
  	 	 	}
  	 	},
  	 	"mining": {
  	 	 	"name": {
- 	 	 	 	"trans": "Навичка майнингу",
+ 	 	 	 	"trans": "навичка майнингу",
  	 	 	 	"eng": "mining skill"
  	 	 	}
  	 	}
@@ -5174,7 +5174,7 @@
  	"location": {
  	 	"mainHub": {
  	 	 	"name": {
- 	 	 	 	"trans": "Центр Шангрі-ла",
+ 	 	 	 	"trans": "Центр Шангрі-Ла",
  	 	 	 	"eng": "Shangri-La City center"
  	 	 	},
  	 	 	"description": {
@@ -5183,7 +5183,7 @@
  	 	 	},
  	 	 	"toStation": {
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Перейти до центрального вокзалу Гіпер-потяга",
+ 	 	 	 	 	"trans": "Перейти до Центрального вокзалу Гіпер-потяга",
  	 	 	 	 	"eng": "Go to Hyper Train Central Station"
  	 	 	 	},
  	 	 	 	"tut": {
@@ -5193,59 +5193,59 @@
  	 	 	},
  	 	 	"toJob": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Перейти до Комерційної Зони Шангрі-ла",
+ 	 	 	 	 	"trans": "Перейти до Комерційної Зони Шангрі-Ла",
  	 	 	 	 	"eng": "Go to Shangri-La Commercial Area"
  	 	 	 	},
  	 	 	 	"tut": {
- 	 	 	 	 	"trans": "Ви можете завершити AFK завдання, щоб підняти рівень своїх навичок тут",
+ 	 	 	 	 	"trans": "Тут ви можете завершити AFK завдання, щоб підвищити рівень своїх навичок",
  	 	 	 	 	"eng": "You can complete AFK jobs to increase your skills here"
  	 	 	 	}
  	 	 	},
  	 	 	"toMarket": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Перейти до Ринку Шангрі-ла",
+ 	 	 	 	 	"trans": "Перейти до Ринку Шангрі-Ла",
  	 	 	 	 	"eng": "Go to Shangri-La Market Street"
  	 	 	 	},
  	 	 	 	"tut": {
- 	 	 	 	 	"trans": "Ви можете продати або купити речі у інших гравців тут",
+ 	 	 	 	 	"trans": "Тут ви можете продавати або купувати речі у інших гравців",
  	 	 	 	 	"eng": "You can sell or buy items from other players here"
  	 	 	 	}
  	 	 	},
  	 	 	"toGang": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "До Штабу ватаги",
+ 	 	 	 	 	"trans": "До Штабу банди",
  	 	 	 	 	"eng": "Go to gang headquarters"
  	 	 	 	}
  	 	 	}
  	 	},
  	 	"job": {
  	 	 	"name": {
- 	 	 	 	"trans": "Комерційна зона Шангрі-ла",
+ 	 	 	 	"trans": "Комерційна зона Шангрі-Ла",
  	 	 	 	"eng": "Shangri-La Commercial Area"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "[Комерційна зона]\r\n        Тут розміщено багато магазинів і бізнесів. Чудове місце для випробування ваших вмінь та навичок.",
+ 	 	 	 	"trans": "[Комерційна зона]\r\n        Тут розміщено багато магазинів і бізнес центрів. Чудове місце для випробування ваших вмінь та навичок.",
  	 	 	 	"eng": "[Job Hub]\r\n        Here are many shops and businesses reside. The perfect location to hone and refine your skills."
  	 	 	},
  	 	 	"toMainHub": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Повернутись до центру Шангрі-ла",
+ 	 	 	 	 	"trans": "Повернутись до центру Шангрі-Ла",
  	 	 	 	 	"eng": "Return to Shangri-La City Center"
  	 	 	 	}
  	 	 	}
  	 	},
  	 	"market": {
  	 	 	"name": {
- 	 	 	 	"trans": "Ринок Шангрі-ла",
+ 	 	 	 	"trans": "Ринок Шангрі-Ла",
  	 	 	 	"eng": "Shangri-La Market Street"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "[Ринок гравців]\r\n        Відомий вуличний ринок в Шангрі-ла, де вулиці наповнені лотками з товарами.\r\n        Може ви щось вгледіте для себе, або ж відкриєте свій власний магазинчик.",
+ 	 	 	 	"trans": "[Ринок Гравців]\r\n        Відомий вуличний ринок в Шангрі-Ла, де вулиці наповнені лотками з товарами.\r\n        Може ви щось вгледіте для себе, або ж відкриєте свій власний магазинчик.",
  	 	 	 	"eng": "[Player Market]\r\n        The famous market street in Shangri-La. Loads of market stalls fill the street."
  	 	 	},
  	 	 	"toMainHub": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "Повернутись до центру Шангрі-ла",
+ 	 	 	 	 	"trans": "Повернутись до центру Шангрі-Ла",
  	 	 	 	 	"eng": "Return to Shangri-La City Center"
  	 	 	 	}
  	 	 	}
@@ -5262,7 +5262,7 @@
  	 	},
  	 	"gang": {
  	 	 	"name": {
- 	 	 	 	"trans": "Штаб Ватаги",
+ 	 	 	 	"trans": "Штаб Банди",
  	 	 	 	"eng": "Gang Headquarters"
  	 	 	},
  	 	 	"description": {
@@ -5270,7 +5270,7 @@
  	 	 	 	"eng": "[Gang]\r\n        The headquarters for you and your gang members to plan and execute your next operation"
  	 	 	},
  	 	 	"cantEnterError": {
- 	 	 	 	"trans": "Вам потрібно приєднатися до ватаги, щоб увійти до цієї зони",
+ 	 	 	 	"trans": "Вам потрібно приєднатися до банди, щоб увійти до цієї зони",
  	 	 	 	"eng": "You need to join a gang to enter this area"
  	 	 	}
  	 	},
@@ -5320,7 +5320,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"segmentDisplayName"
  	 	 	 	],
- 	 	 	 	"trans": "станція ${segmentDisplayName}",
+ 	 	 	 	"trans": "Станція ${segmentDisplayName}",
  	 	 	 	"eng": "${segmentDisplayName} station"
  	 	 	},
  	 	 	"description": {
@@ -5333,7 +5333,7 @@
  	 	 	},
  	 	 	"locked": {
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Зберіть усі 3 фрагменти ключа з Підземель в кожній з 3х зон попередньої станції, \r\n                    тоді йдіть до [Терміналу] в центрі міста [Центр] щоб брут-форсити (виготовити) ключ, необхідний для відкриття цієї зони",
+ 	 	 	 	 	"trans": "Зберіть усі 3 фрагменти ключа з Підземель в кожній з 3-х зон попередньої станції, \r\n                    тоді йдіть до [Терміналу] в центрі міста [Центр] щоб брут-форсити (виготовити) ключ, необхідний для відкриття цієї зони",
  	 	 	 	 	"eng": "Gather all 3 different Key Fragments from Dungeons in each 3 zones in previous station, \r\n                    then go to [Terminal] at City Center [Hub] to brute-force (Craft) the key required to unlock this area"
  	 	 	 	}
  	 	 	},
@@ -5345,7 +5345,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"segmentStationName"
  	 	 	 	],
- 	 	 	 	"trans": "Перейти до ${segmentStationName}",
+ 	 	 	 	"trans": "перейти до ${segmentStationName}",
  	 	 	 	"eng": "go to ${segmentStationName}"
  	 	 	},
  	 	 	"toZone": {
@@ -5353,7 +5353,7 @@
  	 	 	 	 	"vars": [
  	 	 	 	 	 	"segmentStationName"
  	 	 	 	 	],
- 	 	 	 	 	"trans": "Йдіть сюди для бою з ворогом 1го рівня",
+ 	 	 	 	 	"trans": "Йдіть сюди для бою з ворогом 1-го рівня",
  	 	 	 	 	"eng": "Continue here to fight level 1 enemy"
  	 	 	 	},
  	 	 	 	"description": {
@@ -5517,7 +5517,7 @@
  	 	 	 	 	"Незнайомцю, тобі допомогти щось знайти?",
  	 	 	 	 	"Якісна зброя тільки у цього зброяра.",
  	 	 	 	 	"Хочеш собі купити щось, для самозахисту?",
- 	 	 	 	 	"Найкращий зброяр Шангрі-ла до ваших послух.",
+ 	 	 	 	 	"Найкращий зброяр Шангрі-Ла до ваших послух.",
  	 	 	 	 	"Небезпечно іти самому.... а проте,  забудь.",
  	 	 	 	 	"Я теж була авантюристкою, як і ти. Поки не відкрила цей магазинчик.",
  	 	 	 	 	"Товар поверненню та обміну не підлягає. Що купив, те й отримав.",
@@ -5598,7 +5598,7 @@
  	 	 	 	 	"Товар поверненню та обміну не підлягає. В мене не доброчинність.",
  	 	 	 	 	"Гов, малий. Як ти сьогодні?",
  	 	 	 	 	"Не зупиняйся на 7му рівні, бо будеш тут гарувати довічно, як я.",
- 	 	 	 	 	"Найкращий магазин медичного обладнання у всьому Шангрі-ла.",
+ 	 	 	 	 	"Найкращий магазин медичного обладнання у всьому Шангрі-Ла.",
  	 	 	 	 	"SLPD знову піднімає гамір. Сподіваюсь, Рада поставить їх на місце.",
  	 	 	 	 	"Гов, малий, чув про мережу 3Helix?",
  	 	 	 	 	"Гов, малий, бачив когось на ім'я Винищувач світів?",
@@ -5634,7 +5634,7 @@
  	 	 	 	 	"Доброго дня. Це найбезпечніше місце для твоїх найцінніших речей.",
  	 	 	 	 	"Тобі пощастило! Тут твої речі в найбільшій безпеці",
  	 	 	 	 	"Вітаю. Маєте щось до вкладення?",
- 	 	 	 	 	"Вітаю в відділі Шангрі-ла. Чим можу допомогти?",
+ 	 	 	 	 	"Вітаю в відділі Шангрі-Ла. Чим можу допомогти?",
  	 	 	 	 	"Я піднімаю речі, а тоді знову кладу вниз. Жартую, але не зовсім.",
  	 	 	 	 	"Банк Арасаки для всіх ваших банкових потреб.",
  	 	 	 	 	"Вітаю. Який сервіс вам потрібен сьогодні?",
@@ -5812,7 +5812,7 @@
  	"action": {
  	 	"increasePrint": {
  	 	 	"name": {
- 	 	 	 	"trans": "працювати на заводі друку",
+ 	 	 	 	"trans": "Працювати на заводі друку",
  	 	 	 	"eng": "work in printing factory"
  	 	 	},
  	 	 	"description": {
@@ -5862,21 +5862,21 @@
  	 	},
  	 	"clanResource": {
  	 	 	"name": {
- 	 	 	 	"trans": "Зібрати ресурси для ватаги",
+ 	 	 	 	"trans": "Зібрати ресурси для банди",
  	 	 	 	"eng": "Gather Gang Resource"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Допоможіть зібрати необхідні ресурсами для утримання вашої ватаги",
+ 	 	 	 	"trans": "Допоможіть зібрати необхідні ресурсами для утримання вашої банди",
  	 	 	 	"eng": "Help gather and manage needed resources for your gang"
  	 	 	}
  	 	},
  	 	"clanOccupation": {
  	 	 	"name": {
- 	 	 	 	"trans": "Збільшити контроль над Шангрі-ла",
+ 	 	 	 	"trans": "Збільшити контроль над Шангрі-Ла",
  	 	 	 	"eng": "Reinforce occupation at Shangri-la"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Допоможіть зміцнити і встановити більший контроль над містом Шангрі-ла.",
+ 	 	 	 	"trans": "Допоможіть зміцнити і встановити більший контроль над містом Шангрі-Ла.",
  	 	 	 	"eng": "Help reinforce and establish greater control of Shangri-la city."
  	 	 	}
  	 	},
@@ -5916,17 +5916,17 @@
  	 	 	 	"eng": "Collect Protection Fees"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Дайте на лапу місцевим представникам вдали та поліції Шангрі-ла, та зберіть данину за захист з бізнесів та жителів Шангрі-ла. Може вам навіть вдасться отримати ЕПІЧНІ речі? (Тільки для 2х ТОП ватаг в таблиці лідерів)",
+ 	 	 	 	"trans": "Дайте на лапу місцевим представникам вдали та поліції Шангрі-Ла, та зберіть данину за захист з бізнесів та жителів Шангрі-Ла. Може вам навіть вдасться отримати ЕПІЧНІ речі? (Тільки для 2-х ТОП банд в таблиці лідерів)",
  	 	 	 	"eng": "Bribe government officials and the SLPD to collect protection fees from business owners and citizens in Shangri-La. Maybe you’ll get some EPIC items from them? (Exclusive to the Top 2 Gangs on the Occupation Leaderboard"
  	 	 	}
  	 	},
  	 	"globalQuest": {
  	 	 	"name": {
- 	 	 	 	"trans": "Хакнути Фортецю даних Шангрі-ла",
+ 	 	 	 	"trans": "Хакнути Фортецю даних Шангрі-Ла",
  	 	 	 	"eng": "Hack SL Data Fortress"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Розпочніть організовану кібер-атаку Фортеці даних Шангрі-ла\r\n        Якщо атака буде вдалою, можна змусити фортецю даних транслювати експлойти усім кібер-під'єднаним гравцям",
+ 	 	 	 	"trans": "Розпочніть організовану кібер-атаку Фортеці даних Шангрі-Ла\r\n        Якщо атака буде вдалою, можна змусити фортецю даних транслювати експлойти усім кібер-під'єднаним гравцям",
  	 	 	 	"eng": "Launch a collaborative attack in cyberspace targeting the Shangri-La Data Fortress.\r\nIf the attack succeeds, it’s possible to force the Data Fortress to transmit exploits to all cybernetically connected users."
  	 	 	}
  	 	},
@@ -5969,7 +5969,7 @@
  	 	 	 	 	"eng": "Deal damage"
  	 	 	 	},
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "завдайте збитків будь-якому ворогові",
+ 	 	 	 	 	"trans": "Завдайте збитків будь-якому ворогові",
  	 	 	 	 	"eng": "Deal damage to any enemy"
  	 	 	 	}
  	 	 	},
@@ -6088,7 +6088,7 @@
  	"recipe": {
  	 	"unlockLootBox1": {
  	 	 	"name": {
- 	 	 	 	"trans": "Розблокувати сейф",
+ 	 	 	 	"trans": "Розблокувати Контейнер",
  	 	 	 	"eng": "Unlock Container"
  	 	 	}
  	 	},
@@ -6098,19 +6098,19 @@
  	 	},
  	 	"unlockLootBox2": {
  	 	 	"name": {
- 	 	 	 	"trans": "Розблокувати рідкісний сейф",
+ 	 	 	 	"trans": "Розблокувати Рідкісний Контейнер",
  	 	 	 	"eng": "Unlock Rare Container"
  	 	 	}
  	 	},
  	 	"unlockLootBox3": {
  	 	 	"name": {
- 	 	 	 	"trans": "Розблокувати легендарний сейф",
+ 	 	 	 	"trans": "Розблокувати Легендарний Контейнер",
  	 	 	 	"eng": "Unlock Legendary Container"
  	 	 	}
  	 	},
  	 	"christmasGift": {
  	 	 	"name": {
- 	 	 	 	"trans": "Розблокувати таємничий сейф",
+ 	 	 	 	"trans": "Розблокувати Таємничий Контейнер",
  	 	 	 	"eng": "Unlock Mysterious Container"
  	 	 	}
  	 	},
@@ -6150,25 +6150,25 @@
  	 	},
  	 	"aiCoreCluster": {
  	 	 	"name": {
- 	 	 	 	"trans": "Кластер AI ядер",
+ 	 	 	 	"trans": "Кластер AI Ядер",
  	 	 	 	"eng": "AI Core Cluster"
  	 	 	}
  	 	},
  	 	"halloween": {
  	 	 	"name": {
- 	 	 	 	"trans": "Джек О ліхтар",
+ 	 	 	 	"trans": "Джек О Ліхтар",
  	 	 	 	"eng": "Jack O Lantern"
  	 	 	}
  	 	},
  	 	"christmasToBox": {
  	 	 	"name": {
- 	 	 	 	"trans": "Заблокований легендарний контейнер",
+ 	 	 	 	"trans": "Заблокований Легендарний Контейнер",
  	 	 	 	"eng": "Locked Legendary Container"
  	 	 	}
  	 	},
  	 	"lunarLoot": {
  	 	 	"name": {
- 	 	 	 	"trans": "Червоний конверт",
+ 	 	 	 	"trans": "Червоний Конверт",
  	 	 	 	"eng": "Red Envelope"
  	 	 	}
  	 	},
@@ -6201,7 +6201,7 @@
  	 	 	"eng": "Spamming"
  	 	},
  	 	"other": {
- 	 	 	"trans": "Інший",
+ 	 	 	"trans": "Інше",
  	 	 	"eng": "Other"
  	 	}
  	},
@@ -6211,7 +6211,7 @@
  	 	 	"eng": "Synaptic Acceleration"
  	 	},
  	 	"synapticAccelerationRare": {
- 	 	 	"trans": "Синаптичне прискорення (рідкісне)",
+ 	 	 	"trans": "Синаптичне прискорення (Рідкісне)",
  	 	 	"eng": "Synaptic Acceleration (Rare)"
  	 	},
  	 	"expBonus": {
@@ -6227,15 +6227,15 @@
  	 	 	"eng": "Calibration Precision (Common)"
  	 	},
  	 	"upgradeChance2": {
- 	 	 	"trans": "Підвищення Точності Калібрування (рідкісне)",
+ 	 	 	"trans": "Підвищення Точності Калібрування (Рідкісне)",
  	 	 	"eng": "Calibration Precision (Rare)"
  	 	},
  	 	"upgradeChance3": {
- 	 	 	"trans": "Підвищення Точності Калібрування (легендарне)",
+ 	 	 	"trans": "Підвищення Точності Калібрування (Легендарне)",
  	 	 	"eng": "Calibration Precision (Legendary)"
  	 	},
  	 	"upgradeChance4": {
- 	 	 	"trans": "Підвищення Точності Калібрування (престижне)",
+ 	 	 	"trans": "Підвищення Точності Калібрування (Престижне)",
  	 	 	"eng": "Calibration Precision (Prestige)"
  	 	},
  	 	"upgradeNoBreak": {
@@ -6243,7 +6243,7 @@
  	 	 	"eng": "Calibration Safety Nano Bot"
  	 	},
  	 	"afkRewardBoost": {
- 	 	 	"trans": "AFK BOOST",
+ 	 	 	"trans": "AFK буст",
  	 	 	"eng": "AFK Reward Boost"
  	 	},
  	 	"pirate": {
@@ -6277,7 +6277,7 @@
  	},
  	"error": {
  	 	"10_aborted": {
- 	 	 	"trans": "Зіткнувшись з помилкою на стороні сервера, якщо ви побачите це повідомлення, зачекайте 2 хвилини, перш ніж зробити будь -які інші дії, щоб переконатися, що це не буде відбуватися.",
+ 	 	 	"trans": "Виникла помилка на стороні сервера. Якщо ви бачите це повідомлення, зачекайте 2 хвилини, перш ніж робити будь-які інші дії, щоб переконатися, що це більше не повторюватиметься.",
  	 	 	"eng": "Encountered an server side error, if you see this message, please wait for 2 minutes before making any other action to ensure it will not keep happening."
  	 	}
  	},
@@ -6288,7 +6288,7 @@
  	 	 	 	 	"enemyName",
  	 	 	 	 	"value"
  	 	 	 	],
- 	 	 	 	"trans": "${enemyName} напав на вас, вам завдано ${value} удару",
+ 	 	 	 	"trans": "${enemyName} напав на вас, вам завдано ${value} збитку",
  	 	 	 	"eng": "${enemyName} attacked you, received ${value} damage"
  	 	 	},
  	 	 	"playerAttack": {
@@ -6296,7 +6296,7 @@
  	 	 	 	 	"enemyName",
  	 	 	 	 	"value"
  	 	 	 	],
- 	 	 	 	"trans": "Ви напали на ${enemyName}, завдавши ${value} удару",
+ 	 	 	 	"trans": "Ви напали на ${enemyName}, завдавши ${value} збитку",
  	 	 	 	"eng": "You attacked ${enemyName}, dealing ${value} damage"
  	 	 	}
  	 	},
@@ -6305,14 +6305,14 @@
  	 	 	 	"enemy",
  	 	 	 	"player"
  	 	 	],
- 	 	 	"trans": "${enemy} зазнав поразки ${player}",
+ 	 	 	"trans": "${enemy} зазнав поразки від ${player}",
  	 	 	"eng": "${enemy} was defeated by ${player}"
  	 	},
  	 	"gearScoreTooHigh": {
  	 	 	"vars": [
  	 	 	 	"enemy"
  	 	 	],
- 	 	 	"trans": "Середній рівень обладнання занадто високий, щоб отримати винагороду від ${enemy}",
+ 	 	 	"trans": "Ваш середній рівень спорядження занадто високий, щоб обібрати ${enemy}",
  	 	 	"eng": "Your average equipment level is too high to receive reward from ${enemy}"
  	 	}
  	},
@@ -6329,7 +6329,7 @@
  	 	 	 	"amount",
  	 	 	 	"levelName"
  	 	 	],
- 	 	 	"trans": "Ви отримали ${amount} ${levelName} балів досвіду",
+ 	 	 	"trans": "Ви отримали ${amount} ${levelName} досвіду",
  	 	 	"eng": "You received ${amount} ${levelName} experience points"
  	 	},
  	 	"item": {
@@ -6343,7 +6343,7 @@
  	},
  	"chatServer": {
  	 	"restarting": {
- 	 	 	"trans": "Сервер чату перезапускається для оновлення ...",
+ 	 	 	"trans": "Сервер чату перезапускається для оновлення...",
  	 	 	"eng": "Chat Server is restarting for a update..."
  	 	}
  	},
@@ -6363,20 +6363,20 @@
  	},
  	"dungeon": {
  	 	"enemyInRoomDoorError": {
- 	 	 	"trans": "Ви не можете використовувати двері, поки є ще вороги у кімнаті",
+ 	 	 	"trans": "Ви не можете використовувати двері, поки в кімнаті ще є ворог, розберіться з ним",
  	 	 	"eng": "You cannot use door while there is still enemy in room"
  	 	},
  	 	"enemyInCrateDoorError": {
- 	 	 	"trans": "Надто небезпечно шукати цінні речі, поки все ще є вороги неподалік",
+ 	 	 	"trans": "Надто небезпечно шукати цінні речі, поки поруч ще є вороги, варто це виправити...",
  	 	 	"eng": "It is too dangerous to search while there are still enemies nearby"
  	 	},
  	 	"quest": {
  	 	 	"accept": {
- 	 	 	 	"trans": "Взяти квест",
+ 	 	 	 	"trans": "Взяти Завдання",
  	 	 	 	"eng": "Accept Quest"
  	 	 	},
  	 	 	"decline": {
- 	 	 	 	"trans": "Відмовитись від квесту",
+ 	 	 	 	"trans": "Відмовитись від Завдання",
  	 	 	 	"eng": "Decline Quest"
  	 	 	}
  	 	},
@@ -6442,7 +6442,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"zoneName"
  	 	 	 	],
- 	 	 	 	"trans": "Вторгнення в ${zoneName}",
+ 	 	 	 	"trans": "вторгнення в ${zoneName}",
  	 	 	 	"eng": "invade ${zoneName}"
  	 	 	},
  	 	 	"description": {
@@ -6451,7 +6451,7 @@
  	 	 	 	 	"keyFragmentDisplayName",
  	 	 	 	 	"expMultiplier"
  	 	 	 	],
- 	 	 	 	"trans": "Рекомендований рівень:　${maxLevel}+ в групі\r\n                    у ${expMultiplier}x більше досвіду!\r\n                    Підземелля ватаги, додаткова винагорода і досвід. \r\n                    Не для слабких духом",
+ 	 	 	 	"trans": "Рекомендований рівень:　${maxLevel}+ в групі\r\n                    у ${expMultiplier}x більше досвіду!\r\n                    Підземелля банди, додаткова винагорода і досвід. \r\n                    Не для слабких духом",
  	 	 	 	"eng": "Recommended Level: ${maxLevel}+ with co-op\r\n                    ${2.3}x more EXP! and 4~5x stronger enemies!\r\n                    Gang mode dungeon, extra loot and exp.\r\n                    *Not for the faint of heart*"
  	 	 	}
  	 	},
@@ -6460,7 +6460,7 @@
  	 	 	"eng": "Leave dungeon"
  	 	},
  	 	"loading": {
- 	 	 	"trans": "Завантаження підземелля ...",
+ 	 	 	"trans": "Завантаження підземелля...",
  	 	 	"eng": "Loading Dungeon..."
  	 	},
  	 	"shareDungeonModal": {
@@ -6482,7 +6482,7 @@
  	 	 	}
  	 	},
  	 	"shareDungeon": {
- 	 	 	"trans": "Розподіляти",
+ 	 	 	"trans": "Поділитись",
  	 	 	"eng": "Share"
  	 	},
  	 	"buttonTut": {
@@ -6490,7 +6490,7 @@
  	 	 	"eng": "Do you think you are strong enough? take on stronger enemies in dungeon!\r\n                        remember to buy some healing item! you won't regen after battle in dungeon"
  	 	},
  	 	"cleared": {
- 	 	 	"trans": "Підземелля очистився!",
+ 	 	 	"trans": "Підземелля зачищене, гарна робота!",
  	 	 	"eng": "Dungeon cleared!"
  	 	}
  	},
@@ -6498,7 +6498,7 @@
  	 	"ui": {
  	 	 	"useItem": {
  	 	 	 	"localFightCantUseItem": {
- 	 	 	 	 	"trans": "Ви не можете використати цю річ під час вуличних боїв, до використання лише в підземеллях",
+ 	 	 	 	 	"trans": "Ви не можете використати цю річ під час вуличних боїв, доступно лише в підземеллях",
  	 	 	 	 	"eng": "You cannot use item during street fights, items are only available during dungeons"
  	 	 	 	}
  	 	 	},
@@ -6511,18 +6511,18 @@
  	 	},
  	 	"useItemWithExistingBuffModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "Ви впевнені, що хочете використовувати цей предмет?",
+ 	 	 	 	"trans": "Ви впевнені, що хочете використати цей предмет?",
  	 	 	 	"eng": "Are you sure you want to use this item?"
  	 	 	},
  	 	 	"description": {
  	 	 	 	"vars": [
  	 	 	 	 	"remaining"
  	 	 	 	],
- 	 	 	 	"trans": "Використання цього елемента оновить таймер поточного активного бафу і складе ефект, якщо це застосовується. (${remaining})",
+ 	 	 	 	"trans": "Використання цього елемента оновить таймер поточного активного баффа та складе ефект, якщо він застосовний. (${remaining})",
  	 	 	 	"eng": "By using this item will refresh the timer of current active buff and stack the effect if applicable. (${remaining})"
  	 	 	},
  	 	 	"confirmText": {
- 	 	 	 	"trans": "Використання",
+ 	 	 	 	"trans": "Використати",
  	 	 	 	"eng": "Use"
  	 	 	}
  	 	},
@@ -6533,7 +6533,7 @@
  	 	 	 	 	"maxStackSize",
  	 	 	 	 	"newAmount"
  	 	 	 	],
- 	 	 	 	"trans": "Перевищення суми максимальної суми ${itemName} має максимальний розмір стека ${maxStackSize}, але ви намагаєтесь вписатись у ${newAmount}",
+ 	 	 	 	"trans": "Перевищено максимальну допустиму кількість, ${itemName} має максимальну доступну кількість в  ${maxStackSize}, але ви намагаєтеся вміститися в ${newAmount}",
  	 	 	 	"eng": "Exceed item max amount, ${itemName} has max stack size of ${maxStackSize}, but you are trying to fit in ${newAmount}"
  	 	 	},
  	 	 	"full": {
@@ -6541,7 +6541,7 @@
  	 	 	 	 	"neededAmount",
  	 	 	 	 	"size"
  	 	 	 	],
- 	 	 	 	"trans": "Недостатнє місця в інвентарі вимагає ${neededAmount} слотів, але у вас є лише ${size}",
+ 	 	 	 	"trans": "Недостатнє місця в інвентарі, потрібно ${neededAmount} слотів, але у вас є лише ${size} доступних",
  	 	 	 	"eng": "Insufficient space in inventory, requires ${neededAmount} slots, but you only have ${size}"
  	 	 	}
  	 	}
@@ -6549,7 +6549,7 @@
  	"tier": {
  	 	"trash": {
  	 	 	"name": {
- 	 	 	 	"trans": "таке-собі",
+ 	 	 	 	"trans": "сміття",
  	 	 	 	"eng": "trash"
  	 	 	}
  	 	},
@@ -6730,14 +6730,14 @@
  	 	 	"eng": "How many would you like to sell?"
  	 	},
  	 	"upgradeSlot": {
- 	 	 	"trans": "Оновлення",
+ 	 	 	"trans": "Збільшити",
  	 	 	"eng": "Upgrade"
  	 	},
  	 	"upgradeSlotTitle": {
  	 	 	"vars": [
  	 	 	 	"slot"
  	 	 	],
- 	 	 	"trans": "Оновіть слот на ринку до ${slot}",
+ 	 	 	"trans": "Збільшити кількість слотів на ринку до ${slot}",
  	 	 	"eng": "Upgrade Market Slot to ${slot}"
  	 	},
  	 	"upgradeSlotDesc": {
@@ -6745,13 +6745,13 @@
  	 	 	 	"slot",
  	 	 	 	"price"
  	 	 	],
- 	 	 	"trans": "Ви можете збільшити свій ринок до ${slot}, заплативши ${price} біткойни",
+ 	 	 	"trans": "Ви можете збільшити кількість слотів для продажу до ${slot}, заплативши ${price} біткойнів",
  	 	 	"eng": "You can increase your market slot to ${slot} by paying ${price} BitCoins"
  	 	}
  	},
  	"mobile": {
  	 	"returnToAppMessage": {
- 	 	 	"trans": "Синхронізація з сервером ..",
+ 	 	 	"trans": "Синхронізація з сервером...",
  	 	 	"eng": "Syncing with server.."
  	 	}
  	},
@@ -6760,7 +6760,7 @@
  	 	 	"vars": [
  	 	 	 	"segmentDisplayName"
  	 	 	],
- 	 	 	"trans": "таємний ключ ${segmentDisplayName}",
+ 	 	 	"trans": "Таємний ключ ${segmentDisplayName}",
  	 	 	"eng": "${segmentDisplayName} Secret Key"
  	 	},
  	 	"bruteForce": {
@@ -6770,7 +6770,7 @@
  	 	 	 	 	"segmentMinLevel",
  	 	 	 	 	"segmentMaxLevel"
  	 	 	 	],
- 	 	 	 	"trans": "таємний ключ ${segmentDisplayName} (рівень ${segmentMinLevel} - ${segmentMaxLevel})",
+ 	 	 	 	"trans": "Таємний ключ ${segmentDisplayName} (рівень ${segmentMinLevel} - ${segmentMaxLevel})",
  	 	 	 	"eng": "${segmentDisplayName} Secret Key (lv ${segmentMinLevel} - ${segmentMaxLevel})"
  	 	 	}
  	 	},
@@ -6821,7 +6821,7 @@
  	},
  	"shop": {
  	 	"noEnoughSpace": {
- 	 	 	"trans": "Недостатньо місця в кишені, щоб придбати цю річ",
+ 	 	 	"trans": "Недостатньо місця в інвентарі, щоб придбати цю річ",
  	 	 	"eng": "You have no space in your inventory to purchase this item"
  	 	},
  	 	"noEnoughExchangeItem": {
@@ -6848,7 +6848,7 @@
  	 	 	 	 	"amount",
  	 	 	 	 	"itemName"
  	 	 	 	],
- 	 	 	 	"trans": "Купуєте ${amount} ${itemName}",
+ 	 	 	 	"trans": "Купуєте ${itemName} - ${amount}",
  	 	 	 	"eng": "Buying ${amount} of ${itemName}"
  	 	 	},
  	 	 	"priceDisplay": {
@@ -6864,7 +6864,7 @@
  	 	 	 	 	"amount",
  	 	 	 	 	"itemName"
  	 	 	 	],
- 	 	 	 	"trans": "Всього: ${amount} ${itemName}",
+ 	 	 	 	"trans": "Всього: ${itemName} - ${amount}",
  	 	 	 	"eng": "Total: ${amount} ${itemName}"
  	 	 	}
  	 	}
@@ -6879,7 +6879,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"amount"
  	 	 	 	],
- 	 	 	 	"trans": "Це пожертвує ${amount} Юнітів з вашого облікового запису",
+ 	 	 	 	"trans": "Ви пожертвуєте ${amount} Юнітів з вашого облікового запису",
  	 	 	 	"eng": "This will donate ${amount} Unit from your account"
  	 	 	},
  	 	 	"notEnough": {
@@ -6901,7 +6901,7 @@
  	 	 	 	"eng": "View Profile"
  	 	 	},
  	 	 	"openPlayerGang": {
- 	 	 	 	"trans": "Ватага",
+ 	 	 	 	"trans": "Банда",
  	 	 	 	"eng": "View Gang"
  	 	 	},
  	 	 	"sendGift": {
@@ -6945,7 +6945,7 @@
  	 	 	 	"eng": "You will be MUTED if you breach any of the rules"
  	 	 	},
  	 	 	"footer2": {
- 	 	 	 	"trans": "Повний перелік правил тут: Профіль> Інструкція > Правила",
+ 	 	 	 	"trans": "Повний перелік правил тут: Профіль > Інструкція > Правила",
  	 	 	 	"eng": "Full list of rules can be found in Profile > Tutorials > Rules"
  	 	 	},
  	 	 	"agreeToggle": {
@@ -6975,11 +6975,11 @@
  	 	 	 	"eng": "Player contributed content"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Ви можете зробити свій внесок до різних видів контенту, шляхом редагування файлів конфігурації на нашій сторінці Github.",
+ 	 	 	 	"trans": "Ви можете внести свій внесок у цей та до багато іншого контенту, редагуючи файли конфігурації на нашій сторінці GitHub.",
  	 	 	 	"eng": "You can contribute to content like this and many more too by editing the config files in our GitHub page."
  	 	 	},
  	 	 	"confirm": {
- 	 	 	 	"trans": "Йти до github",
+ 	 	 	 	"trans": "Перейти до github",
  	 	 	 	"eng": "Go to GitHub"
  	 	 	},
  	 	 	"cancel": {
@@ -6997,7 +6997,7 @@
  	 	 	 	"eng": "View Details"
  	 	 	},
  	 	 	"swap": {
- 	 	 	 	"trans": "Замінити обладнання",
+ 	 	 	 	"trans": "замінити обладнання",
  	 	 	 	"eng": "replace equipment"
  	 	 	}
  	 	},
@@ -7067,7 +7067,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"levelName"
  	 	 	 	],
- 	 	 	 	"trans": "Вітаю! Ви підвищили ${levelName}!",
+ 	 	 	 	"trans": "Вітаю! Ви підвищили свій рівень до ${levelName}!",
  	 	 	 	"eng": "Congratulation, you have leveled up your ${levelName}!"
  	 	 	},
  	 	 	"fromTo": {
@@ -7141,7 +7141,7 @@
  	 	 	 	"eng": "An update has been installed"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Натисніть Перезавантажити, щоб продовжити",
+ 	 	 	 	"trans": "Натисніть \"Перезавантажити\", щоб продовжити",
  	 	 	 	"eng": "Please click reload to continue"
  	 	 	},
  	 	 	"reloadButton": {
@@ -7211,18 +7211,18 @@
  	 	 	"vars": [
  	 	 	 	"time"
  	 	 	],
- 	 	 	"trans": "Доступно ще раз у ${time}",
+ 	 	 	"trans": "Доступно ще раз через ${time}",
  	 	 	"eng": "Available again in ${time}"
  	 	},
  	 	"freeButton": {
  	 	 	"text": {
- 	 	 	 	"trans": "Претензія безкоштовно",
+ 	 	 	 	"trans": "Забрати даром",
  	 	 	 	"eng": "Claim for free"
  	 	 	}
  	 	},
  	 	"purchaseButton": {
  	 	 	"text": {
- 	 	 	 	"trans": "Закупівля",
+ 	 	 	 	"trans": "Придбати",
  	 	 	 	"eng": "Purchase"
  	 	 	}
  	 	}
@@ -7240,7 +7240,7 @@
  	 	},
  	 	"gangShortNameInput": {
  	 	 	"title": {
- 	 	 	 	"trans": "День банди",
+ 	 	 	 	"trans": "Тег банди",
  	 	 	 	"eng": "Gang Tag"
  	 	 	},
  	 	 	"description": {
@@ -7267,11 +7267,11 @@
  	},
  	"christmasPromo": {
  	 	"title": {
- 	 	 	"trans": "Зимового свята!",
+ 	 	 	"trans": "Щасливих Зимових свят!",
  	 	 	"eng": "Happy Winter Holiday!"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "Це найдивовижніша пора року знову! У Shangri-La ми святкуємо зимове свято з спеціальною подією!",
+ 	 	 	"trans": "Знову найпрекрасніша пора року! У Шангрі-Ла ми святкуємо зимове свято з спеціальною подією!",
  	 	 	"eng": "It's the most wonderful time of the year again! in Shang-ri-la we are celebrating the winter holiday with a special event!"
  	 	},
  	 	"desc2": {
@@ -7279,11 +7279,11 @@
  	 	 	 	"itemName",
  	 	 	 	"craftItem"
  	 	 	],
- 	 	 	"trans": "Вороги та AI Core Auto Farm матимуть шанс скинути ${itemName}, ви можете використовувати це для Craft ${craftItem} або відкрити його безпосередньо!",
+ 	 	 	"trans": "Вороги та Автоферма AI Ядер матимуть шанс викинути ${itemName}, ви можете використати це, щоб створити ${craftItem} або відкрити його безпосередньо!",
  	 	 	"eng": "Enemies and AI Core auto farm will have chance to drop ${itemName}, you can use this to craft ${craftItem} or open it directly!"
  	 	},
  	 	"desc3": {
- 	 	 	"trans": "Під час сезону відпусток буде доступний двома обмеженими чатами та емблемою!",
+ 	 	 	"trans": "У святковий сезон будуть доступні рамка для чату і емблема!",
  	 	 	"eng": "During the holiday season, two time limited chat frame and emblem will be available!"
  	 	}
  	},
@@ -7293,25 +7293,25 @@
  	 	 	"eng": "Happy Halloween!"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "Це моторошна пора року знову! Шан-Рі-Ла святкує Хеллоуїн із спеціальною подією!",
+ 	 	 	"trans": "Це моторошна пора року знову! Шанг-Рі-Ла святкує Хеллоуїн із спеціальною подією!",
  	 	 	"eng": "Its the spooky time of the year again! Shang-ri-la is celebrating Halloween with a special event!"
  	 	},
  	 	"desc2": {
- 	 	 	"trans": "Вороги та AI Core Auto Farm матимуть шанс скинути Джек-О-Літернс! Ви можете використовувати їх для виготовлення замкнених легендарних контейнерів!",
+ 	 	 	"trans": "Вороги та Автоферма AI Ядер матимуть шанс викинути ліхтарики Джека! ви можете використовувати їх для створення Замкнутих Легендарних Контейнерів!",
  	 	 	"eng": "Enemies and AI Core auto farm will have chance to drop Jack-o-lanterns! you can use these to craft Locked Legendary Containers!"
  	 	},
  	 	"desc3": {
- 	 	 	"trans": "Під час Хеллоуїна буде доступний рівень пожертвування чату з кібер-батом!",
+ 	 	 	"trans": "Під час Хелловіну буде доступний обмежений за часом рівень пожертвувань - КіберКажан!",
  	 	 	"eng": "During Halloween, a time limited cyber-bat chat donation tier will be available!"
  	 	}
  	},
  	"lunarPromo": {
  	 	"title": {
- 	 	 	"trans": "Щасливий місячний Новий рік!",
+ 	 	 	"trans": "З Новим роком за місячним календарем!",
  	 	 	"eng": "Happy Lunar New year!"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "Місячний Новий рік тут, і ми святкуємо в Шан-Рі-Ла із спеціальною подією. Приєднуйтесь до нас, коли ми сприймаємо початок нового року, наповнене традиціями, радістю та спільністю.",
+ 	 	 	"trans": "Новий рік за місячним календарем настав, і ми святкуємо його в Шанг-рі-ла спеціальною подією. Приєднуйтесь до нас, коли ми зустрічаємо початок нового року, наповненого традиціями, радістю та єдністю.",
  	 	 	"eng": "The lunar new year is here, and we're celebrating in Shang-ri-la with a special event. Join us as we embrace the start of a new year, filled with traditions, joy, and togetherness."
  	 	},
  	 	"desc2": {
@@ -7321,7 +7321,7 @@
  	 	 	 	"llcName",
  	 	 	 	"npcName"
  	 	 	],
- 	 	 	"trans": "${npcShopName} тепер відкритий для бізнесу! Ви можете використовувати ${coinItem}, щоб придбати різні спеціальні кухні та ${llcName} з ${npcName}!",
+ 	 	 	"trans": "${npcShopName} тепер відкрито! Ви можете використовувати ${coinItem}, щоб придбати різноманітні спеціальні страви та ${llcName} у ${npcName}!",
  	 	 	"eng": "${npcShopName} is now open for business! You can use ${coinItem} to purchase various special cuisines and ${llcName} from ${npcName}!"
  	 	},
  	 	"desc3": {
@@ -7329,7 +7329,7 @@
  	 	 	 	"envelopItem",
  	 	 	 	"coinItem"
  	 	 	],
- 	 	 	"trans": "Це не новий рік, якщо ${envelopItem} не задіяний! Вороги та AI Core Auto Farm знизить ${envelopItem}, відкрийте їх, щоб отримати випадкову суму ${coinItem}!",
+ 	 	 	"trans": "Це не новий рік, якщо ${envelopItem} не задіяний! Вороги та автоферма AI Ядер викинуть ${envelopItem}, відкрийте їх, щоб отримати випадкову суму ${coinItem}!",
  	 	 	"eng": "It's not new year if ${envelopItem} is not involved! Enemies and AI Core auto farm will drop ${envelopItem}, open them to receive random amount of ${coinItem}!"
  	 	},
  	 	"desc4": {
@@ -7337,7 +7337,7 @@
  	 	 	 	"envelopItem",
  	 	 	 	"npcShop"
  	 	 	],
- 	 	 	"trans": "Тепер ви можете отримувати 3 безкоштовно ${envelopItem} в ${npcShop} щодня!",
+ 	 	 	"trans": "Тепер ви можете отримувати 3 безкоштовні ${envelopItem} в ${npcShop} щодня!",
  	 	 	"eng": "You can now receive 3 free ${envelopItem} in ${npcShop} every day!"
  	 	},
  	 	"desc5": {
@@ -7347,19 +7347,19 @@
  	},
  	"referralPromo": {
  	 	"title": {
- 	 	 	"trans": "Зверніться до своїх друзів, щоб отримати дивовижні нагороди!",
+ 	 	 	"trans": "Запрошуйте друзів, щоб отримати чудові нагороди!",
  	 	 	"eng": "Refer your friends to get amazing rewards!"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "Безкоштовний Юніт*",
+ 	 	 	"trans": "Безкоштовні Юніти*",
  	 	 	"eng": "Free Unit*"
  	 	},
  	 	"desc2": {
- 	 	 	"trans": "Рідкісна заблокована ємність",
+ 	 	 	"trans": "Рідкісний Заблокований Контейнер",
  	 	 	"eng": "Rare Locked Container"
  	 	},
  	 	"desc3": {
- 	 	 	"trans": "Фан-пакет",
+ 	 	 	"trans": "Барсетка",
  	 	 	"eng": "Fanny Pack"
  	 	},
  	 	"instruction": {
@@ -7368,12 +7368,12 @@
  	 	 	 	"eng": "How to refer?"
  	 	 	},
  	 	 	"step1": {
- 	 	 	 	"trans": "1. Попросіть свого друга ввести своє ім’я в грі під час створення персонажів",
+ 	 	 	 	"trans": "1. Попросіть свого друга ввести своє ім’я в грі під час створення нового персонажа\n2. І все!",
  	 	 	 	"eng": "2. done, thats it!"
  	 	 	}
  	 	},
  	 	"footnote1": {
- 	 	 	"trans": "*Ви отримуєте 10% бонусних юнітів, коли ваш друг купує юніта",
+ 	 	 	"trans": "*Ви отримуєте 10% бонусних юнітів, коли ваш друг купуватиме юніти",
  	 	 	"eng": "*you get 10% bonus unit whenever your friend purchases unit"
  	 	},
  	 	"footnote2": {
@@ -7386,11 +7386,11 @@
  	 	 	"vars": [
  	 	 	 	"playerName"
  	 	 	],
- 	 	 	"trans": "звітування ${playerName}",
+ 	 	 	"trans": "звітування про ${playerName}",
  	 	 	"eng": "reporting ${playerName}"
  	 	},
  	 	"description": {
- 	 	 	"trans": "Звіт автоматично надсилатиметься модераторам. \\ Неприйняйте не зловживають, спамувати і не грати з системою звітів",
+ 	 	 	"trans": "Звіт автоматично надсилатиметься модераторам. \nБудь ласка, не зловживайте, не розсилайте спам і не грайтеся з системою звітів",
  	 	 	"eng": "Report will be sent to moderators automatically. \\nPlease do not misuses, spamming or play with the report system"
  	 	},
  	 	"textInput": {
@@ -7405,7 +7405,7 @@
  	 	},
  	 	"error": {
  	 	 	"otherNoText": {
- 	 	 	 	"trans": "Звіти типу \"інші\" потребують опису",
+ 	 	 	 	"trans": "Звіти типу \"Інші\" потребують опису",
  	 	 	 	"eng": "Report type of \"Other\" needs a description"
  	 	 	},
  	 	 	"noReportType": {
@@ -7425,7 +7425,7 @@
  	 	 	"vars": [
  	 	 	 	"amount"
  	 	 	],
- 	 	 	"trans": "Вибрана сума: ${amount}",
+ 	 	 	"trans": "Вибрана кількість: ${amount}",
  	 	 	"eng": "Selected amount: ${amount}"
  	 	}
  	},
@@ -7440,18 +7440,18 @@
  	 	 	 	}
  	 	 	},
  	 	 	"kick": {
- 	 	 	 	"trans": "Удар",
+ 	 	 	 	"trans": "Вигнати",
  	 	 	 	"eng": "Kick",
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Везіть інших гравців від вашої банди.",
+ 	 	 	 	 	"trans": "Виганяйте інших гравців зі своєї банди.",
  	 	 	 	 	"eng": "Kick other players from your gang."
  	 	 	 	}
  	 	 	},
  	 	 	"manage": {
- 	 	 	 	"trans": "Керувати",
+ 	 	 	 	"trans": "Керування",
  	 	 	 	"eng": "Manage",
  	 	 	 	"description": {
- 	 	 	 	 	"trans": "Дозвольте цьому гравцеві керувати дозволом інших гравців",
+ 	 	 	 	 	"trans": "Дозволити цьому гравцеві керувати дозволами інших гравців",
  	 	 	 	 	"eng": "Allow this player to manage permission of other players"
  	 	 	 	}
  	 	 	}
@@ -7464,7 +7464,7 @@
  	 	 	"vars": [
  	 	 	 	"topGangs"
  	 	 	],
- 	 	 	"trans": "Ви не в топ -банді. Топ -банди: ${topGangs}",
+ 	 	 	"trans": "Ви не в топ банді. Топ банди: ${topGangs}",
  	 	 	"eng": "You are not in a top gang. Top gangs are: ${topGangs}"
  	 	}
  	},
@@ -7480,7 +7480,7 @@
  	},
  	"craftingStartPage": {
  	 	"instant": {
- 	 	 	"trans": "Мить",
+ 	 	 	"trans": "Миттєво",
  	 	 	"eng": "Instant"
  	 	},
  	 	"instantDescription": {
@@ -7511,7 +7511,7 @@
  	 	 	"vars": [
  	 	 	 	"price"
  	 	 	],
- 	 	 	"trans": "${price} USD на місяць",
+ 	 	 	"trans": "${price} (USD) на місяць",
  	 	 	"eng": "${price} USD Per Month"
  	 	},
  	 	"TiersTitle": {
@@ -7537,11 +7537,11 @@
  	 	 	 	"date",
  	 	 	 	"relative"
  	 	 	],
- 	 	 	"trans": "Обмежене додавання до ${date} (кінець ${relative})",
+ 	 	 	"trans": "Обмежене видання до ${date} (кінець ${relative})",
  	 	 	"eng": "Limited edition till ${date} (end in ${relative})"
  	 	},
  	 	"permanentDescription": {
- 	 	 	"trans": "Це звання довічне. \n Воно залишається з вашим обліковим записом назавжди.",
+ 	 	 	"trans": "Це звання довічне.\nВоно залишається за вами назавжди.",
  	 	 	"eng": "This title will never expire.\\nIt stays with your account forever."
  	 	}
  	},
@@ -7556,7 +7556,7 @@
  	},
  	"forgotPasswordPage": {
  	 	"title": {
- 	 	 	"trans": "Введіть свою електронну пошту, система надішле вам електронний лист із скиданням пароля",
+ 	 	 	"trans": "Введіть свою електронну пошту, система надішле вам електронний лист для скиданням пароля",
  	 	 	"eng": "Enter your email, the system will send a reset password email to you"
  	 	},
  	 	"emailRequired": {
@@ -7571,7 +7571,7 @@
  	 	 	"vars": [
  	 	 	 	"email"
  	 	 	],
- 	 	 	"trans": "Електронна пошта скидання пароля надіслана на {електронну пошту}",
+ 	 	 	"trans": "Лист для скидання пароля надіслано на ${email}",
  	 	 	"eng": "An password reset email has been sent to {email}"
  	 	},
  	 	"checkEmail": {
@@ -7581,7 +7581,7 @@
  	},
  	"sendCosmeticPage": {
  	 	"donationTabTitle": {
- 	 	 	"trans": "Чат",
+ 	 	 	"trans": "Рамка Чату",
  	 	 	"eng": "Chat Frame"
  	 	},
  	 	"emblemTab": {
@@ -7594,11 +7594,11 @@
  	 	 	"vars": [
  	 	 	 	"playerName"
  	 	 	],
- 	 	 	"trans": "Надсилання косметики на ${playerName}",
+ 	 	 	"trans": "Надсилання косметики ${playerName}",
  	 	 	"eng": "Sending cosmetic to ${playerName}"
  	 	},
  	 	"description": {
- 	 	 	"trans": "Не надсилайте косметику гравцям, яких ви не знаєте і не використовуєте його як частину торгівлі. Ця функція повинна використовуватися лише як подарунок вашому другові",
+ 	 	 	"trans": "Не надсилайте косметику гравцям, яких ви не знаєте, і не використовуйте її як частину торгівлі. Цю функцію слід використовувати лише як подарунок вашому другові",
  	 	 	"eng": "Do not send cosmetic to players you do not know or use it as part of a trade. this feature should only be used as a gift to your friend"
  	 	},
  	 	"confirmModal": {
@@ -7608,15 +7608,15 @@
  	 	 	 	 	"playerName",
  	 	 	 	 	"price"
  	 	 	 	],
- 	 	 	 	"trans": "Надіслати ${donationName} кадр чату пожертви (вартість ${price} одиниці) на програвач \"${playerName}\"?",
+ 	 	 	 	"trans": "Надіслати ${donationName} рамку чату (вартістю ${price} Юнітів) гравцю \"${playerName}\"?",
  	 	 	 	"eng": "Send ${donationName} donation chat frame (cost ${price} Unit) to player \"${playerName}\"?"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Натиснувши підтвердження, ви погоджуєтесь, що ви не надсилаєте цей косметичний подарунок як частину торгівлі, і є суто подарунком своєму другові, не очікуючи повернення.",
+ 	 	 	 	"trans": "Натиснувши кнопку \"Підтвердити\", ви погоджуєтеся, що ви не надсилаєте цей косметичний подарунок як частину торгівлі, а лише як подарунок вашому другові без очікуваного повернення або оплати.",
  	 	 	 	"eng": "By clicking confirm, you agree that you are not sending this cosmetic gift as part of a trade and is purely a gift to your friend with no return expected."
  	 	 	},
  	 	 	"confirmText": {
- 	 	 	 	"trans": "Підтверджувати",
+ 	 	 	 	"trans": "Підтвердити",
  	 	 	 	"eng": "Confirm"
  	 	 	}
  	 	},
@@ -7625,26 +7625,26 @@
  	 	 	 	"donationName",
  	 	 	 	"playerName"
  	 	 	],
- 	 	 	"trans": "Ви успішно надіслали ${donationName} кадр чату пожертвування гравцеві \"${playerName}\"",
+ 	 	 	"trans": "Ви успішно надіслали ${donationName} рамку чату гравцеві \"${playerName}\"",
  	 	 	"eng": "You have successfully sent ${donationName} donation chat frame to player \"${playerName}\""
  	 	},
  	 	"hasDonation": {
- 	 	 	"trans": "власний",
+ 	 	 	"trans": "у власності",
  	 	 	"eng": "owned"
  	 	},
  	 	"donationPrice": {
  	 	 	"vars": [
  	 	 	 	"price"
  	 	 	],
- 	 	 	"trans": "${price} блок",
+ 	 	 	"trans": "${price} Юнітів",
  	 	 	"eng": "${price} Unit"
  	 	},
  	 	"donationDescription": {
- 	 	 	"trans": "Обдарований рівень пожертвування тривалий протягом 30 днів",
+ 	 	 	"trans": "Даровані пожертви активні лише 30 днів",
  	 	 	"eng": "Gifted donation tier last for 30 days"
  	 	},
  	 	"emblemNotIncluded": {
- 	 	 	"trans": "Емблема не включається в подарунок",
+ 	 	 	"trans": "Емблема в подарунок не входить",
  	 	 	"eng": "Emblem is not included in gift"
  	 	}
  	},
@@ -7653,11 +7653,11 @@
  	 	 	"vars": [
  	 	 	 	"playerName"
  	 	 	],
- 	 	 	"trans": "Надсилання косметики на ${playerName}",
+ 	 	 	"trans": "Надсилання косметики гравцю ${playerName}",
  	 	 	"eng": "Sending cosmetic to ${playerName}"
  	 	},
  	 	"description": {
- 	 	 	"trans": "Не надсилайте косметику гравцям, яких ви не знаєте і не використовуєте його як частину торгівлі. Ця функція повинна використовуватися лише як подарунок вашому другові",
+ 	 	 	"trans": "Не надсилайте косметику гравцям, яких ви не знаєте і не використовуєте її як частину торгівлі. Ця функція повинна використовуватися лише як подарунок вашому другові",
  	 	 	"eng": "Do not send cosmetic to players you do not know or use it as part of a trade. this feature should only be used as a gift to your friend"
  	 	},
  	 	"confirmModal": {
@@ -7666,15 +7666,15 @@
  	 	 	 	 	"playerName",
  	 	 	 	 	"price"
  	 	 	 	],
- 	 	 	 	"trans": "Надіслати емблему (вартість ${price} одиниці) на програвач \"${playerName}\"?",
+ 	 	 	 	"trans": "Надіслати емблему (вартістю ${price} Юнітів) гравцю \"${playerName}\"?",
  	 	 	 	"eng": "Send emblem (cost ${price} Unit) to player \"${playerName}\"?"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "Натиснувши підтвердження, ви погоджуєтесь, що ви не надсилаєте цей косметичний подарунок як частину торгівлі, і є суто подарунком своєму другові, не очікуючи повернення.",
+ 	 	 	 	"trans": "Натиснувши кнопку \"Підтвердити\", ви погоджуєтеся, що ви не надсилаєте цей косметичний подарунок як частину торгівлі, а лише як подарунок вашому другові без очікуваного повернення або оплати.",
  	 	 	 	"eng": "By clicking confirm, you agree that you are not sending this cosmetic gift as part of a trade and is purely a gift to your friend with no return expected."
  	 	 	},
  	 	 	"confirmText": {
- 	 	 	 	"trans": "Підтверджувати",
+ 	 	 	 	"trans": "Підтвердити",
  	 	 	 	"eng": "Confirm"
  	 	 	}
  	 	},
@@ -7689,15 +7689,15 @@
  	"player": {
  	 	"error": {
  	 	 	"deleteWhileMuted": {
- 	 	 	 	"trans": "Ви не можете видалити свій рахунок, коли ви приглушені.",
+ 	 	 	 	"trans": "Ви не можете видалити свій обліковий запис, якщо ви заглушені.",
  	 	 	 	"eng": "You can't delete your account when you are muted."
  	 	 	},
  	 	 	"deleteAccountTooEarly": {
- 	 	 	 	"trans": "Ви не можете видалити цей рахунок зараз, зачекайте кілька днів",
+ 	 	 	 	"trans": "Ви не можете видалити цей обліковий запис зараз, зачекайте кілька днів",
  	 	 	 	"eng": "You can't delete this account now, please wait a few days"
  	 	 	},
  	 	 	"playerNotFound": {
- 	 	 	 	"trans": "Гравець не знайдено",
+ 	 	 	 	"trans": "Гравця не знайдено",
  	 	 	 	"eng": "Player not found"
  	 	 	},
  	 	 	"notInBattle": {
@@ -7709,7 +7709,7 @@
  	 	 	 	"eng": "You can't perform this action now"
  	 	 	},
  	 	 	"invalidTravelLink": {
- 	 	 	 	"trans": "Недійсне посилання на подорож, якщо наполегливо перезавантажте",
+ 	 	 	 	"trans": "Недійсне посилання на подорож. Якщо воно не зникне, перезавантажте його",
  	 	 	 	"eng": "Invalid Travel Link, if persist please reload"
  	 	 	}
  	 	},
@@ -7730,7 +7730,7 @@
  	 	 	"vars": [
  	 	 	 	"enemy"
  	 	 	],
- 	 	 	"trans": "`Вас убили ${enemy}",
+ 	 	 	"trans": "`Вас вбив ${enemy}",
  	 	 	"eng": "`You were killed by ${enemy}"
  	 	},
  	 	"levelTooHigh": {
@@ -7739,34 +7739,34 @@
  	 	},
  	 	"giveCred": {
  	 	 	"success": {
- 	 	 	 	"trans": "Ви дали щоденний вуличний кредит.",
+ 	 	 	 	"trans": "Ви підвищили репутацію.",
  	 	 	 	"eng": "You have given daily street cred."
  	 	 	},
  	 	 	"notEnoughLevelError": {
- 	 	 	 	"trans": "Ви повинні бути рівнем 10 або вище, щоб дати Clayer Street Cred",
+ 	 	 	 	"trans": "Ви повинні бути рівня 10 або вище, щоб підвищити репутацію",
  	 	 	 	"eng": "You must be level 10 or above to give player street cred"
  	 	 	},
  	 	 	"cooldownError": {
- 	 	 	 	"trans": "Ви ще не можете дати вулиці (раз на день)",
+ 	 	 	 	"trans": "Ви ще не можете дати репутацію (раз на день)",
  	 	 	 	"eng": "You cannot give street cred yet (once every day)"
  	 	 	}
  	 	}
  	},
  	"basicInfo": {
  	 	"nameUsed": {
- 	 	 	"trans": "Це ім'я використовується іншим гравцем, будь ласка, використовуйте інше ім’я",
+ 	 	 	"trans": "це ім'я використовується іншим гравцем, використовуйте інше ім'я",
  	 	 	"eng": "this name is used by other player, please use other name"
  	 	},
  	 	"nameIllegal": {
- 	 	 	"trans": "Незаконне ім’я, будь ласка, використовуйте інше ім’я",
+ 	 	 	"trans": "Неприпустиме ім'я, використовуйте інше ім'я",
  	 	 	"eng": "Illegal name, please use other name"
  	 	},
  	 	"nameProfane": {
- 	 	 	"trans": "Це ім'я містить дозволені слова, будь ласка, використовуйте інше ім’я",
+ 	 	 	"trans": "Це ім'я містить недозволені слова або формулювання, використовуйте інше ім'я",
  	 	 	"eng": "This name contains wordings not allowed, please use other name"
  	 	},
  	 	"nameInvalid": {
- 	 	 	"trans": "Довжина імені повинна бути більшою, ніж 4, менше, ніж дорівнює 16 і містить лише англійські символи, цифри або \\ '_ \\'",
+ 	 	 	"trans": "довжина імені має бути більше 4 символів, менше 17 символів і містити лише англійські літери, цифри або \\' _\\'",
  	 	 	"eng": "name length must be greater then 4, less then or equal to 16 and only contains English characters, numbers or \\'_\\'"
  	 	}
  	},
@@ -7776,7 +7776,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"time"
  	 	 	 	],
- 	 	 	 	"trans": "Здається, існує такий же ефект статусу, розгорнутий вже іншим гравцем. Ви можете знову розгорнути ${time} хвилину.",
+ 	 	 	 	"trans": "Схоже, такий самий ефект статусу вже застосовує інший гравець. Ви можете спробувати знову через ${time}хв.",
  	 	 	 	"eng": "Seems like there is a same status effect deployed by other player already. you may deploy again in ${time} minute."
  	 	 	}
  	 	}


### PR DESCRIPTION
I found a Ukrainian translation is pretty bad, so I spent a few hours looking through the app and translation file to optimize and adapt it for a better user experience

The changelog is too huge to describe everything, but in short:  Many words were misspelled; 
Some variables were not properly used; 
Some phrases were incorrectly used;
Some names are now more "canon", (in a show of respect to CDPR :) )