### PR TITLE
Better DE translations

### DIFF
--- a/contribution/lang/de.json
+++ b/contribution/lang/de.json
@@ -1062,7 +1062,7 @@
  	 	 	},
  	 	 	"levelSelect": {
  	 	 	 	"title": {
- 	 	 	 	 	"trans": "Eben",
+ 	 	 	 	 	"trans": "Level",
  	 	 	 	 	"eng": "Level"
  	 	 	 	}
  	 	 	},
@@ -2029,7 +2029,7 @@
  	 	 	 	"eng": "Item Inbox"
  	 	 	},
  	 	 	"descriptionV2": {
- 	 	 	 	"trans": "Die Artikel hier werden automatisch in Ihr Inventar verschoben, sobald Sie genügend Platz haben.",
+ 	 	 	 	"trans": "Die Gegenstände hier werden automatisch in Ihr Inventar verschoben, sobald Sie genügend Platz haben.",
  	 	 	 	"eng": "Items here will be automatically moved to your inventory once you have enough space."
  	 	 	},
  	 	 	"descriptionV3": {
@@ -2048,7 +2048,7 @@
  	 	 	 	"eng": "There is no item in your item inbox"
  	 	 	},
  	 	 	"tooManyItems": {
- 	 	 	 	"trans": "In Ihrem Posteingang gibt es möglicherweise mehr Artikel, aber Sie haben zu viele Artikel in Ihrem Posteingang, um sie alle anzuzeigen.",
+ 	 	 	 	"trans": "In Ihrem Posteingang gibt es möglicherweise mehr Gegenstände, aber Sie haben zu viele Gegenstände in Ihrem Posteingang, um sie alle anzuzeigen.",
  	 	 	 	"eng": "There might be more items in your inbox, but you have too many items in your inbox to display them all."
  	 	 	},
  	 	 	"getAllItems": {
@@ -2153,7 +2153,7 @@
  	 	 	 	"eng": "You must be idle to do this action"
  	 	 	},
  	 	 	"noItem": {
- 	 	 	 	"trans": "Sie haben keinen Artikel zum Verkauf",
+ 	 	 	 	"trans": "Sie haben keinen Gegenstand zum Verkauf",
  	 	 	 	"eng": " You current don't have any item on sale"
  	 	 	}
  	 	},
@@ -2315,7 +2315,7 @@
  	 	 	 	"eng": "Select Container"
  	 	 	},
  	 	 	"hint": {
- 	 	 	 	"trans": "Schalten Sie einen Container frei, um die Artikel hineinzubekommen, und erfordert eine geringe Menge an technischen Abfällen",
+ 	 	 	 	"trans": "Schalten Sie einen Container frei, um die Gegenstände hineinzubekommen, und erfordert eine geringe Menge an technischen Abfällen",
  	 	 	 	"eng": "Unlock a container to get the items inside, requires small amount of tech scraps"
  	 	 	},
  	 	 	"increaseEpicDropRate": {
@@ -2650,13 +2650,13 @@
  	},
  	"inventory": {
  	 	"scrap": {
- 	 	 	"trans": "Schrott",
+ 	 	 	"trans": "Verschrotten",
  	 	 	"eng": "scrap"
  	 	},
  	 	"ui": {
  	 	 	"useItem": {
  	 	 	 	"localFightCantUseItem": {
- 	 	 	 	 	"trans": "Du kannst diesen Gegenstand während eines Straßenkämpf nicht verwenden, Gegenstände sind nur in Dungeons verfügbar",
+ 	 	 	 	 	"trans": "Du kannst diesen Gegenstand während eines Straßenkampfes nicht verwenden, Gegenstände sind nur in Dungeons verfügbar",
  	 	 	 	 	"eng": "You cannot use item during street fights, items are only available during dungeons"
  	 	 	 	}
  	 	 	},
@@ -2669,7 +2669,7 @@
  	 	},
  	 	"useItemWithExistingBuffModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "bist du sicher, dass du diesen Artikel verwenden möchten?",
+ 	 	 	 	"trans": "bist du sicher, dass du diesen Gegenstand verwenden möchten?",
  	 	 	 	"eng": "Are you sure you want to use this item?"
  	 	 	},
  	 	 	"description": {
@@ -3607,7 +3607,7 @@
  	},
  	"slider": {
  	 	"min": {
- 	 	 	"trans": "Mindest",
+ 	 	 	"trans": "Min",
  	 	 	"eng": "Min"
  	 	},
  	 	"max": {
@@ -3657,7 +3657,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"itemName"
  	 	 	 	],
- 	 	 	 	"trans": "Verdoppeln Sie die Artikel und exp! während die Dauer und die Kosten um das 4 -fache steigen",
+ 	 	 	 	"trans": "Verdoppeln Sie die Anzahl der Gegenstände und exp! während die Dauer und die Kosten um das 4 -fache steigen",
  	 	 	 	"eng": "Double the items and exp! while the duration and cost will increase by 4 times"
  	 	 	},
  	 	 	"activate": {
@@ -3727,7 +3727,7 @@
  	 	 	 	"eng": "You can not start a trade when you are not idle"
  	 	 	},
  	 	 	"targetPlayerBlockedYou": {
- 	 	 	 	"trans": "Sie können keine Handelsladung an diesen Spieler senden",
+ 	 	 	 	"trans": "Sie können keine Handelseinladung an diesen Spieler senden",
  	 	 	 	"eng": "You cannot send trade invite to this player"
  	 	 	},
  	 	 	"targetPlayerBlockedGifts": {
@@ -3736,7 +3736,7 @@
  	 	 	},
  	 	 	"targetPlayerLimited": {
  	 	 	 	"trans": "Zielspieler kann nicht am Handel teilnehmen",
- 	 	 	 	"eng": "You cannot send trade invite to this player"
+ 	 	 	 	"eng": "Target player cannot participate in trade"
  	 	 	},
  	 	 	"tooFrequentlyInvite": {
  	 	 	 	"vars": [
@@ -3749,7 +3749,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"maxItems"
  	 	 	 	],
- 	 	 	 	"trans": "Sie können nicht mehr als ${maxItems} Artikel pro Spieler hinzufügen",
+ 	 	 	 	"trans": "Sie können nicht mehr als ${maxItems} Gegenstände pro Spieler hinzufügen",
  	 	 	 	"eng": "You cannot add more than ${maxItems} items per player"
  	 	 	},
  	 	 	"notEnoughItems": {
@@ -4093,7 +4093,7 @@
  	 	 	"eng": "CyberKitty"
  	 	},
  	 	"donation12": {
- 	 	 	"trans": "Cyberanta",
+ 	 	 	"trans": "CyberSanta",
  	 	 	"eng": "CyberSanta"
  	 	},
  	 	"donation13": {
@@ -5509,7 +5509,7 @@
  	 	 	 	 	"time",
  	 	 	 	 	"costMult"
  	 	 	 	],
- 	 	 	 	"trans": "Während Shard aktiv ist, können alle Spieler bestimmte AFK -Aufgaben im Boost -Modus ™ starten, wodurch ${rewardMult} x belohnt wird und gleichzeitig die Kosten und die Dauer um ${costMult} x erhöht. \\ n * Dieser Artikel ist immer noch Beta und unterliegt einem Gleichgewicht. Bitte verwenden Sie sofort nach dem Kauf *",
+ 	 	 	 	"trans": "Während Shard aktiv ist, können alle Spieler bestimmte AFK -Aufgaben im Boost -Modus ™ starten, wodurch ${rewardMult} x belohnt wird und gleichzeitig die Kosten und die Dauer um ${costMult} x erhöht. \\ n * Dieser Gegenstand ist immer noch Beta und unterliegt Anpassungen. Bitte verwenden Sie sofort nach dem Kauf *",
  	 	 	 	"eng": "While shard is active all players can choose to start certain AFK tasks in Boost Mode™, gaining ${rewardMult}x reward while increasing cost and duration by ${costMult}x. \\n* This item is still beta and subject to balance change, please use immediately after purchase *"
  	 	 	}
  	 	},
@@ -7069,7 +7069,7 @@
  	 	 	"vars": [
  	 	 	 	"itemName"
  	 	 	],
- 	 	 	"trans": "Sie haben nicht genug ${itemName}, um diesen Artikel zu kaufen",
+ 	 	 	"trans": "Sie haben nicht genug ${itemName}, um diesen Gegenstand zu kaufen",
  	 	 	"eng": "You have no enough ${itemName} to purchase this item"
  	 	},
  	 	"noEnoughMoney": {
@@ -7339,8 +7339,8 @@
  	 	 	"eng": "*you get 10% bonus unit whenever your friend purchases unit"
  	 	},
  	 	"footnote2": {
- 	 	 	"trans": "*Sie erhalten die Zeiten in Ihrem Artikel -Posteingang, wenn Ihr Freund Level 20 erreicht",
- 	 	 	"eng": "*You will receive the times in your item inbox when your friend reaches level 20"
+ 	 	 	"trans": "*Sie erhalten die Gegenstände in Ihrem Gegenstand -Posteingang, wenn Ihr Freund Level 20 erreicht",
+ 	 	 	"eng": "*You will receive the items in your item inbox when your friend reaches level 20"
  	 	}
  	},
  	"reportPlayerModal": {
@@ -7378,7 +7378,7 @@
  	},
  	"selectItemModal": {
  	 	"noItems": {
- 	 	 	"trans": "Keine verfügbaren Artikel",
+ 	 	 	"trans": "Keine verfügbaren Gegenstände",
  	 	 	"eng": "No available items"
  	 	}
  	},


### PR DESCRIPTION
Using better words and fixing changes which have been overwritten recently.

- "Artikel" is something that is in your shopping cart. An "Item" is better translated as "Gegenstand"
- Inventory scrap button used the noun for "scrap", while it should use the verb "to scrap" in German
- targetPlayerLimited seems to have the English text messed up
- Typos