### PR TITLE
Update help instructions and unify tier prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ If you would like to help to maintain CyberCode Online, please feel free to subm
 
 ### Help Needed:
 
--   contribution/words.json - Random Words
--   contribution/dungeon/layout/structure-mask.json - Dungeon Layouts 
--   contribution/mobile/{lang}/tips.md - Tips for Mobile
--   contribution/mobile/{lang}/tutorial/\*.md - Tutorial
--   contribution/mobile/{lang}/procedural-names - equipment names
--   contribution/mobile/{lang}/item/lore - item lore
--   contribution/mobile/{lang}/scenario/\*\* - drop lore
--   contribution/mobile/{lang}/dungeon-lore/\*\* - dungeon lore
--   tips.txt - Tips for desktop
--   tutorial/\* - Desktop Tutorial
--   contribution/lang/ - Localizations
+- contribution/words.json - Random Words
+- contribution/dungeon/layout/structure-mask.json - Dungeon Layouts 
+- contribution/mobile/{lang}/tips.md - Tips for Mobile
+- contribution/mobile/{lang}/tutorial/\*.md - Tutorial
+- contribution/mobile/{lang}/procedural-names - equipment names  
+  **Note**: In order to keep things less confusing, please avoid adding additional tier prefixes.
+- contribution/mobile/{lang}/item/lore - item lore
+- contribution/mobile/{lang}/scenario/\*\* - drop lore
+- contribution/mobile/{lang}/dungeon-lore/\*\* - dungeon lore
+- tips.txt - Tips for desktop
+- tutorial/\* - Desktop Tutorial
+- contribution/lang/ - Localizations
 
 ### Simply edit file tutorial
 

--- a/contribution/mobile/en/procedural-names.json
+++ b/contribution/mobile/en/procedural-names.json
@@ -7,27 +7,10 @@
 	},
 	"TIERS": {
 		"TRASH": {
-			"prefixes": [
-				"Compromised",
-				"Corrupted",
-				"Defective",
-				"Degraded",
-				"Obsolete",
-				"Rejected",
-				"Rusty",
-				"Subpar"
-			]
+			"prefixes": [ "Subpar" ]
 		},
 		"COMMON": {
-			"prefixes": [
-				"Average",
-				"Common",
-				"Ordinary",
-				"Plain",
-				"Standard",
-				"Typical",
-				"Unremarkable"
-			]
+			"prefixes": [ "Common" ]
 		},
 		"HIGH_QUALITY": {
 			"prefixes": ["High-Quality"]

--- a/contribution/mobile/en/procedural-names.json
+++ b/contribution/mobile/en/procedural-names.json
@@ -7,7 +7,7 @@
 	},
 	"TIERS": {
 		"TRASH": {
-			"prefixes": [ "Subpar" ]
+			"prefixes": [ "Trash" ]
 		},
 		"COMMON": {
 			"prefixes": [ "Common" ]


### PR DESCRIPTION
Related: https://github.com/DexterHuang/CyberCodeOnline/pull/3138

This pull request unifies the prefix names so that they fall in line with all the others.  It also updates the help instructions to prevent others from making similar mistakes/contributions.