### PR TITLE
Correct translation of "Party"

### DIFF
--- a/contribution/lang/de.json
+++ b/contribution/lang/de.json
@@ -7624,11 +7624,11 @@
  	 	 	"eng": "Cyberspace Connection"
  	 	},
  	 	"globalParty": {
- 	 	 	"trans": "Globale Partei",
+ 	 	 	"trans": "Globale Feier",
  	 	 	"eng": "Global Party"
  	 	},
  	 	"afkExp": {
- 	 	 	"trans": "AFK EXP -Boost",
+ 	 	 	"trans": "AFK EXP Boost",
  	 	 	"eng": "AFK EXP Boost"
  	 	}
  	},


### PR DESCRIPTION
The current translation is "political party", fixed it. 