### PR TITLE
Update ja.json

### DIFF
--- a/contribution/lang/ja.json
+++ b/contribution/lang/ja.json
@@ -8,7 +8,7 @@
  	 	 	"eng": "${playerName}'s Apartment"
  	 	},
  	 	"terminateLease": {
- 	 	 	"trans": "契約を終了します",
+ 	 	 	"trans": "契約を終了する",
  	 	 	"eng": "Terminate Lease"
  	 	},
  	 	"viewPets": {
@@ -17,7 +17,7 @@
  	 	},
  	 	"address": {
  	 	 	"cityName": {
- 	 	 	 	"trans": "シャングリラ",
+ 	 	 	 	"trans": "シャングリ・ラ",
  	 	 	 	"eng": "Shangri-la"
  	 	 	}
  	 	},
@@ -26,11 +26,11 @@
  	 	 	 	"vars": [
  	 	 	 	 	"amount"
  	 	 	 	],
- 	 	 	 	"trans": "アパートの家賃${amount}を支払いました。",
+ 	 	 	 	"trans": "アパートの家賃${amount}を支払いました.",
  	 	 	 	"eng": "You have paid your apartment rent of ${amount}"
  	 	 	},
  	 	 	"unpaidMail": {
- 	 	 	 	"trans": "アパートの家賃を払うのを怠ったため、アパートを解約されました。",
+ 	 	 	 	"trans": "アパートの家賃を滞納したため, アパートを解約されました.",
  	 	 	 	"eng": "You have failed to pay your apartment rent, your apartment has been terminated"
  	 	 	}
  	 	}
@@ -42,12 +42,12 @@
  	 	 	 	"eng": "Rent Apartment"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "このアパートを借りるのは本気でいいの？",
+ 	 	 	 	"trans": "本当にこのアパートを借りますか？",
  	 	 	 	"eng": "Are you sure you want to rent this apartment?"
  	 	 	}
  	 	},
  	 	"rentButton": {
- 	 	 	"trans": "今すぐレンタル",
+ 	 	 	"trans": "今すぐ借りる",
  	 	 	"eng": "Rent Now"
  	 	}
  	},
@@ -1080,6 +1080,14 @@
  	 	 	 	 	"trans": "ブロックプレーヤー",
  	 	 	 	 	"eng": "Block Player"
  	 	 	 	}
+ 	 	 	},
+ 	 	 	"equipped": {
+ 	 	 	 	"trans": "装備品",
+ 	 	 	 	"eng": "Equipped"
+ 	 	 	},
+ 	 	 	"inventory": {
+ 	 	 	 	"trans": "インベントリ",
+ 	 	 	 	"eng": "Inventory"
  	 	 	}
  	 	},
  	 	"modal": {
@@ -2696,6 +2704,10 @@
  	 	 	"trans": "獲得報酬",
  	 	 	"eng": "Receives"
  	 	},
+ 	 	"inputPlaceholder": {
+ 	 	 	"trans": "メッセージを入力してください",
+ 	 	 	"eng": "Enter message to start chatting"
+ 	 	},
  	 	"moderators": {
  	 	 	"trans": "モデレーター",
  	 	 	"eng": "moderators"
@@ -3873,7 +3885,7 @@
  	 	},
  	 	"revive": {
  	 	 	"alreadyActivated": {
- 	 	 	 	"trans": "ペットの養子縁組バフがすでにアクティブ化されています。",
+ 	 	 	 	"trans": "ペット里親探しバフがすでに発動しています。",
  	 	 	 	"eng": "Pet Adoption buff is already activated"
  	 	 	},
  	 	 	"announcement": {
@@ -3888,7 +3900,7 @@
  	 	 	 	"eng": "Pet revive buff activated"
  	 	 	},
  	 	 	"notActivated": {
- 	 	 	 	"trans": "ペットの採用バフがアクティブ化されていません。",
+ 	 	 	 	"trans": "ペット里親探しバフが発動していません。",
  	 	 	 	"eng": "Pet Adoption buff is not activated"
  	 	 	},
  	 	 	"success": {
@@ -3904,7 +3916,7 @@
  	 	 	 	"vars": [
  	 	 	 	 	"hours"
  	 	 	 	],
- 	 	 	 	"trans": "プレイヤーのペットとのインタラクションは、${hours}時間ごとに1回だけ可能です。",
+ 	 	 	 	"trans": "プレイヤーのペットと交流できるのは、${hours}時間に1度だけです。",
  	 	 	 	"eng": "You can only interact with a player's pet once every ${hours} hours"
  	 	 	}
  	 	},
@@ -3934,13 +3946,13 @@
  	 	 	 	"player",
  	 	 	 	"pet"
  	 	 	],
- 	 	 	"trans": "${player}は${pet}を採用しました。",
+ 	 	 	"trans": "${player}は${pet}の里親になりました。",
  	 	 	"eng": "${player} has adopted ${pet}",
  	 	 	"mail": {
  	 	 	 	"vars": [
  	 	 	 	 	"pet"
  	 	 	 	],
- 	 	 	 	"trans": "${pet}を採用しました",
+ 	 	 	 	"trans": "${pet}の里親になりました",
  	 	 	 	"eng": "You have adopted ${pet}"
  	 	 	}
  	 	}
@@ -4263,7 +4275,7 @@
  	 	"apartmentType": {
  	 	 	"T1": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "スラムアパート",
+ 	 	 	 	 	"trans": "スラム街のアパート",
  	 	 	 	 	"eng": "slum apartment"
  	 	 	 	}
  	 	 	},
@@ -4275,7 +4287,7 @@
  	 	 	},
  	 	 	"T3": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "高級アパートメント",
+ 	 	 	 	 	"trans": "高級アパート",
  	 	 	 	 	"eng": "luxury apartment"
  	 	 	 	}
  	 	 	},
@@ -4607,7 +4619,7 @@
  	 	 	"eng": "Skip Lord"
  	 	},
  	 	"donation28": {
- 	 	 	"trans": "桜",
+ 	 	 	"trans": "SAKURA",
  	 	 	"eng": "Sakura"
  	 	},
  	 	"moderator": {
@@ -5667,35 +5679,39 @@
  	 	"donation28": {
  	 	 	"benefits": {
  	 	 	 	"1": {
- 	 	 	 	 	"trans": "\"桜\" 寄付タイトル",
+ 	 	 	 	 	"trans": "称号「SAKURA」",
  	 	 	 	 	"eng": "\"Sakura\" donation title"
  	 	 	 	},
  	 	 	 	"2": {
- 	 	 	 	 	"trans": "プロフィール画像のカスタマイズを解除",
+ 	 	 	 	 	"trans": "プロフィール写真を設定可能",
  	 	 	 	 	"eng": "Unlock profile picture customization"
  	 	 	 	},
  	 	 	 	"3": {
- 	 	 	 	 	"trans": "桜のフレーム（アニメーション付き）",
+ 	 	 	 	 	"trans": "SAKURAフレーム（アニメーション付き）",
  	 	 	 	 	"eng": "Sakura frame (with animation)"
  	 	 	 	},
  	 	 	 	"4": {
- 	 	 	 	 	"trans": "サクラプロフィール（アニメーション付き）",
+ 	 	 	 	 	"trans": "SAKURAプロフィール（アニメーション付き）",
  	 	 	 	 	"eng": "Sakura Profile (with animation)"
  	 	 	 	},
+ 	 	 	 	"5": {
+ 	 	 	 	 	"trans": "自己紹介欄のカスタマイズ機能開放",
+ 	 	 	 	 	"eng": "Unlock custom bio"
+ 	 	 	 	},
  	 	 	 	"6": {
- 	 	 	 	 	"trans": "カスタムバイオを解除",
+ 	 	 	 	 	"trans": "桜のプロフィール装飾",
  	 	 	 	 	"eng": "Sakura profile decoration"
  	 	 	 	},
  	 	 	 	"7": {
- 	 	 	 	 	"trans": "ギャングのモットーをカスタマイズする",
+ 	 	 	 	 	"trans": "ギャングモットーを設定可能",
  	 	 	 	 	"eng": "Customize gang motto"
  	 	 	 	},
  	 	 	 	"8": {
- 	 	 	 	 	"trans": "ギャングのイメージをカスタマイズ",
+ 	 	 	 	 	"trans": "ギャング画像を設定可能",
  	 	 	 	 	"eng": "Customize gang image"
  	 	 	 	},
  	 	 	 	"9": {
- 	 	 	 	 	"trans": "今後のアップデートでさらに追加されます。",
+ 	 	 	 	 	"trans": "今後のアップデートで更なる要素を追加予定",
  	 	 	 	 	"eng": "More coming in future update"
  	 	 	 	}
  	 	 	}
@@ -5786,7 +5802,7 @@
  	 	},
  	 	"sakura": {
  	 	 	"name": {
- 	 	 	 	"trans": "イベント中は${percent}%オフ",
+ 	 	 	 	"trans": "イベント期間中は${percent}%オフ",
  	 	 	 	"eng": "${percent}% off during event",
  	 	 	 	"vars": [
  	 	 	 	 	"percent"
@@ -6769,44 +6785,44 @@
  	 	},
  	 	"pawCredit": {
  	 	 	"name": {
- 	 	 	 	"trans": "ポークレジット",
+ 	 	 	 	"trans": "ペットアイテムクレジット",
  	 	 	 	"eng": "Paw Credit"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "ネオンポウサンクチュアリでペットアイテムと交換できるクレジット",
+ 	 	 	 	"trans": "ネオン動物保護センターでペットアイテムと交換できるクレジット",
  	 	 	 	"eng": "A credit that can be used to exchange pet items at Neon Paw Sanctuary"
  	 	 	}
  	 	},
  	 	"petToken": {
  	 	 	"name": {
- 	 	 	 	"trans": "ボランティアサービスメダリオン",
+ 	 	 	 	"trans": "ペット譲渡パス",
  	 	 	 	"eng": "Sanctuary Adoption Pass"
  	 	 	},
  	 	 	"description": {
  	 	 	 	"vars": [
  	 	 	 	 	"amount"
  	 	 	 	],
- 	 	 	 	"trans": "${amount}を組み合わせてSanctuary Adoption Passを入手し、新しいペットを飼うことができます。",
+ 	 	 	 	"trans": "${amount}を組み合わせてペット譲渡パスを入手し、ネオン動物保護センターで新しいペットを飼うことができます。",
  	 	 	 	"eng": "A pass that can be used to adopt a pet from Neon Paw Sanctuary"
  	 	 	}
  	 	},
  	 	"petFood": {
  	 	 	"name": {
- 	 	 	 	"trans": "エレクトロファイバーバイト",
+ 	 	 	 	"trans": "エレクトロファイバースナック",
  	 	 	 	"eng": "ElectroFiber Bites"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "\"ElectroFiber Bites™には、エネルギーを伝導し蓄える複合繊維が含まれており、サイバーの荒野での長時間の冒険に備えて、ペットのスタミナとパワーを高めます。\"",
+ 	 	 	 	"trans": "エレクトロファイバースナック™は、エネルギー伝導・貯蔵を行う複合繊維配合により、ペットの持久力とパワーを向上させ、サイバーな荒野での長距離探検をサポートするおやつです。",
  	 	 	 	"eng": "\"ElectroFiber Bites™ contain a complex blend of fibers that conduct and store energy, boosting your pet's stamina and power for longer expeditions in the cyber wilderness.\""
  	 	 	}
  	 	},
  	 	"petToy": {
  	 	 	"name": {
- 	 	 	 	"trans": "ナノニブルボール",
+ 	 	 	 	"trans": "ナノ粒子ニブルボール",
  	 	 	 	"eng": "NanoNibble Ball"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "\"ナノニブルボールの登場 - 純粋な喜びのために設計されたプレイタイムテクノロジーの驚異。触れるだけで美しいパターンで光り輝く各ボールは、ペットが十分に楽しまれることを保証します。前代未聞の楽しみのセッションの後、ボールはスマートに無害でエコフレンドリーな粒子に分解され、後片付けの必要はありません。一度きりの忘れられないデジタルコンパニオンシップの冒険に最適で、すっきりと消える究極のプレイタイム体験です。\"",
+ 	 	 	 	"trans": "革新的な遊びのテクノロジーの結晶、ナノ粒子ニブルボールをご紹介します。至上の喜びをもたらすように設計されたこのボールは、わずかなタッチで魅惑的なパターンに点灯し、ペットを飽きさせない玩具です。前代未聞の楽しいひとときの後、このボールはなんと分解され、無害で環境に優しい粒子となり、後片付けの心配もありません。デジタルな仲間との忘れられない冒険体験にぴったり。最高に楽しく遊べて、後片付けも不要な、消えてしまうボールです。",
  	 	 	 	"eng": "\"Introducing the NanoNibble Ball – a marvel of playtime technology designed for sheer joy. Each ball lights up with mesmerizing patterns at the slightest touch, ensuring your pet is thoroughly entertained. After a session of unprecedented fun, the ball smartly deconstructs into harmless, eco-friendly particles, leaving no mess behind. Perfect for a single, unforgettable adventure in digital companionship, it’s the ultimate playtime experience that neatly disappears, sparing you the cleanup.\""
  	 	 	}
  	 	},
@@ -6816,7 +6832,7 @@
  	 	 	 	"eng": "FurFlush Spray"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "ファーフラッシュスプレー：スリムな缶には「即座にキレイ、即座に消える」と書かれています。さっとスプレーするだけで、汚れたペットがピカピカになります。洗い流し不要、汚れもなし、ふわっと消える！サイバーミートアップの直前の「おっと」瞬間に最適です。注意：予期せぬペットのイカツさを引き起こすかもしれません。都市探検家の相棒にぴったりの使い捨て魔法。使用後は消え去り、まばゆいペット以外の証拠は残りません。",
+ 	 	 	 	"trans": "ファーフラッシュスプレー：洗練されたボトルには「一瞬で洗浄、一瞬で消える」の文字が。シュッとひと吹きで、汚れたペットがピカピカに！ すすぎも拭き取りも不要。ただシュッとするだけ！ サイバーミーティング前の「あわわ」な瞬間もこれで安心。注意: 思いがけないペットのイキイキした態度を引き起こす可能性があります。都会探検のパートナーのための、使い切りの魔法です。使用後は消えてしまい、ただ眩いばかりのペットだけが残ります。",
  	 	 	 	"eng": "FurFlush Spray: The sleek canister reads 'Instant Clean, Instant Gone.' A quick spritz turns your grimy pet gleaming—no rinse, no mess, just poof! Perfect for those 'oops' moments before a cyber meet-up. Caution: May lead to unexpected pet swagger. Single-use magic for the urban explorer's companion. Disappears after use, leaving no evidence except a dazzling pet."
  	 	 	}
  	 	},
@@ -6826,7 +6842,7 @@
  	 	 	 	"eng": "PawfectCure"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "ペットが調子悪いときやなんだか元気がないときは、これを使うべし。鼻水から「変なものを食べた」ブルーまで何でも解決。副作用には注意：突然、あなたの料理に対する感謝が高まり、スネuggle攻撃が増加するかもしれない。時には、最高の治療法は少しの笑い... そしてPawfectCure。",
+ 	 	 	 	"trans": "ペットがちょっと元気がない時、何か調子悪いかな？そんな時はこのペット用万能薬が頼りになります。 ちょっとした風邪から「なんか変なもの食べちゃった」まで、これ一本で解決！ 副作用にご注意ください: 急にあなたの料理がおいしく感じたり、スリスリ攻撃が増える可能性があります。だって、たまには笑って、パーフェクトキュアで治すのが一番ですからね。",
  	 	 	 	"eng": "When your pet's feeling under the weather, or just plain off, this is the go-to. It tackles everything from the sniffles to the 'I ate something weird' blues. Beware of side effects: may cause a sudden appreciation for your cooking and an increase in snuggle attacks. Because sometimes, the best remedy is a little laughter... and PawfectCure."
  	 	 	}
  	 	},
@@ -6971,7 +6987,7 @@
  	 	 	},
  	 	 	"toApartment": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "アパートに行こう。",
+ 	 	 	 	 	"trans": "アパートへ行く",
  	 	 	 	 	"eng": "Go to your apartment"
  	 	 	 	}
  	 	 	}
@@ -7034,12 +7050,12 @@
  	 	},
  	 	"apartment": {
  	 	 	"name": {
- 	 	 	 	"trans": "マイアパート",
+ 	 	 	 	"trans": "自分のアパート",
  	 	 	 	"eng": "My Apartment"
  	 	 	},
  	 	 	"toMainHub": {
  	 	 	 	"name": {
- 	 	 	 	 	"trans": "シャングリラシティセンターに戻る",
+ 	 	 	 	 	"trans": "シャングリ・ラ中心街へ戻る",
  	 	 	 	 	"eng": "Return to Shangri-La City Center"
  	 	 	 	}
  	 	 	},
@@ -7627,11 +7643,11 @@
  	 	"petShop": {
  	 	 	"defaultLines": {
  	 	 	 	"trans": [
- 	 	 	 	 	"Hey, choom! Neon Paws is for the brave. These sprites need your daily grind. Ready to dive in?",
- 	 	 	 	 	"Lookin' sharp, netrunner! Here, pets are more than code, they need your daily hack to thrive.",
- 	 	 	 	 	"What's up, street samurai? Partner with a survivor. Without your daily deeds, they're zeroed.",
- 	 	 	 	 	"Edge runner, eh? This is where tech meets heart. Ignore them, and they vanish into the net. Daily care, got it?",
- 	 	 	 	 	"Cyberdeck in hand, heart on sleeve? Our critters need that daily touch or they'll fade into the static."
+ 	 	 	 	 	"よう兄弟！ネオン動物保護センターは勇敢なヤツらのための場所だ。ペットたちは毎日の世話を必要としてるぜ。飛び込む準備はいいか？",
+ 	 	 	 	 	"格好いいじゃないか、ネットランナー！ここではペットはただのコードじゃない。毎日のお手入れが欠かせないんだ。",
+ 	 	 	 	 	"ストリートサムライ、調子はどうだ？共に生きる仲間を見つけよう。ただし、毎日世話しないと彼らは消え去ってしまうぞ。",
+ 	 	 	 	 	"エッジランナーか？ここはテクノロジーと心が交わる場所だ。無視するとネットの中に消えちまうぞ。毎日の世話、忘れるなよ。",
+ 	 	 	 	 	"サイバーデッキは持っていても心は温かいんだろ？ うちの子たちは毎日触れ合ってないと、ノイズの中に消えちまうんだ。"
  	 	 	 	],
  	 	 	 	"eng": [
  	 	 	 	 	"Hey, choom! Neon Paws is for the brave. These sprites need your daily grind. Ready to dive in?",
@@ -7642,7 +7658,7 @@
  	 	 	 	]
  	 	 	},
  	 	 	"name": {
- 	 	 	 	"trans": "ネオン・ポーズ・サンクチュアリー",
+ 	 	 	 	"trans": "ネオン動物保護センター",
  	 	 	 	"eng": "Neon Paws Sanctuary"
  	 	 	},
  	 	 	"npcName": {
@@ -7705,7 +7721,7 @@
  	 	 	"eng": "Hungry"
  	 	},
  	 	"starving": {
- 	 	 	"trans": "腹ぺこ",
+ 	 	 	"trans": "とても腹ぺこ",
  	 	 	"eng": "Starving"
  	 	},
  	 	"wellFed": {
@@ -7717,7 +7733,7 @@
  	 	 	"eng": "Dirty"
  	 	},
  	 	"filthy": {
- 	 	 	"trans": "汚い",
+ 	 	 	"trans": "とても汚い",
  	 	 	"eng": "Filthy"
  	 	},
  	 	"dead": {
@@ -7729,7 +7745,7 @@
  	 	 	"eng": "Unhappy"
  	 	},
  	 	"depressed": {
- 	 	 	"trans": "落ち込んでいます",
+ 	 	 	"trans": "とても憂鬱",
  	 	 	"eng": "Depressed"
  	 	}
  	},
@@ -7868,11 +7884,11 @@
  	 	},
  	 	"petAFK": {
  	 	 	"name": {
- 	 	 	 	"trans": "保護施設ボランティアシフト",
+ 	 	 	 	"trans": "ペット保護施設ボランティア",
  	 	 	 	"eng": "Pet Shelter Volunteer Shift"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "地元の動物保護施設でボランティア活動して、動物たちのお世話を手伝おう。",
+ 	 	 	 	"trans": "地元のペット保護施設でボランティア活動して、動物たちのお世話を手伝おう。",
  	 	 	 	"eng": "Volunteer at the local pet shelter to help take care of the animals."
  	 	 	}
  	 	},
@@ -8243,7 +8259,7 @@
  	 	},
  	 	"craftPetToken": {
  	 	 	"name": {
- 	 	 	 	"trans": "クラフトサンクチュアリー養子縁組パス",
+ 	 	 	 	"trans": "ペット譲渡パスのクラフト",
  	 	 	 	"eng": "Craft Sanctuary Adoption Pass"
  	 	 	}
  	 	},
@@ -8374,7 +8390,7 @@
  	 	 	"eng": "Pet revival is now available during this buff duration."
  	 	},
  	 	"petDraw": {
- 	 	 	"trans": "ペットの里親制度を開始しました。",
+ 	 	 	"trans": "ペットの里親探しが開始されました。",
  	 	 	"eng": "Pet Adoption Activated"
  	 	},
  	 	"petDrawDesc": {
@@ -8814,26 +8830,26 @@
  	},
  	"petDetailsPage": {
  	 	"dispose": {
- 	 	 	"trans": "廃棄する",
+ 	 	 	"trans": "手放す",
  	 	 	"eng": "dispose"
  	 	},
  	 	"disposeConfirmModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "廃棄する",
+ 	 	 	 	"trans": "手放す",
  	 	 	 	"eng": "dispose"
  	 	 	},
  	 	 	"message": {
- 	 	 	 	"trans": "本当にこのペットを処分しますか？この操作は取り消せません。",
+ 	 	 	 	"trans": "本当にこのペットを手放しますか？この操作は取り消せません。",
  	 	 	 	"eng": "Are you sure you want to dispose of this pet? this cannot be undone"
  	 	 	}
  	 	},
  	 	"rerollImage": {
- 	 	 	"trans": "再ロール画像",
+ 	 	 	"trans": "画像の再抽選",
  	 	 	"eng": "re-roll Image"
  	 	},
  	 	"rerollImageConfirmModal": {
  	 	 	"title": {
- 	 	 	 	"trans": "再ロール画像",
+ 	 	 	 	"trans": "画像の再抽選",
  	 	 	 	"eng": "re-roll Image"
  	 	 	},
  	 	 	"message": {
@@ -8858,7 +8874,7 @@
  	 	 	"eng": "status"
  	 	},
  	 	"noStatus": {
- 	 	 	"trans": "健康",
+ 	 	 	"trans": "健康度",
  	 	 	"eng": "healthy"
  	 	},
  	 	"deadRemoveMessage": {
@@ -8869,26 +8885,26 @@
  	 	 	"eng": "will be removed at ${date}"
  	 	},
  	 	"hunger": {
- 	 	 	"trans": "空腹",
+ 	 	 	"trans": "空腹度",
  	 	 	"eng": "Hunger"
  	 	},
  	 	"feed": {
- 	 	 	"trans": "フィード",
+ 	 	 	"trans": "餌をやる",
  	 	 	"eng": "Feed"
  	 	},
  	 	"noFood": {
  	 	 	"vars": [
  	 	 	 	"item"
  	 	 	],
- 	 	 	"trans": "ペットにエサをやるのに${item}がないよ",
+ 	 	 	"trans": "ペットにエサをやるのに${item}がありません",
  	 	 	"eng": "You don't have ${item} to feed your pet"
  	 	},
  	 	"happiness": {
- 	 	 	"trans": "幸福",
+ 	 	 	"trans": "幸福度",
  	 	 	"eng": "Happiness"
  	 	},
  	 	"play": {
- 	 	 	"trans": "プレイ",
+ 	 	 	"trans": "遊ぶ",
  	 	 	"eng": "Play"
  	 	},
  	 	"noToy": {
@@ -8899,11 +8915,11 @@
  	 	 	"eng": "You don't have ${item} to play with your pet"
  	 	},
  	 	"cleanliness": {
- 	 	 	"trans": "清潔liness",
+ 	 	 	"trans": "清潔度",
  	 	 	"eng": "Cleanliness"
  	 	},
  	 	"clean": {
- 	 	 	"trans": "クリーン",
+ 	 	 	"trans": "きれいにする",
  	 	 	"eng": "Clean"
  	 	},
  	 	"noCleaner": {
@@ -9425,7 +9441,7 @@
  	 	 	"eng": "Sakura Festival"
  	 	},
  	 	"desc1": {
- 	 	 	"trans": "春祭りだぜ！桜の花びらが舞い落ち、空気は花の香りで満たされている。",
+ 	 	 	"trans": "が来ました！ 桜の花びらが舞い散り、あたり一面に花の香りが漂っています。",
  	 	 	"eng": "The Spring Festival is here! Sakura petals are falling, and the air is filled with the fragrance of flowers. "
  	 	},
  	 	"desc2": {
@@ -9436,11 +9452,11 @@
  	 	 	"eng": "All skips during the event period gets ${percent}% off discount on unit required"
  	 	},
  	 	"desc3": {
- 	 	 	"trans": "期間限定で、エクスクルーシブな桜のチャットフレームとエンブレムが入手可能です。",
+ 	 	 	"trans": "イベント期間中は、限定の桜のチャットフレームとエンブレムが手に入ります。",
  	 	 	"eng": "Exclusive Sakura chat frame and emblem is available during event period"
  	 	},
  	 	"chatMessage1": {
- 	 	 	"trans": "春が来たぜ",
+ 	 	 	"trans": "春が来ました",
  	 	 	"eng": "Spring is here"
  	 	},
  	 	"desc": {
@@ -9988,11 +10004,11 @@
  	 	 	 	"eng": "Buff is not activated"
  	 	 	},
  	 	 	"cooldown": {
- 	 	 	 	"trans": "ペットの里親探しはクールダウン中だ。",
+ 	 	 	 	"trans": "ペットの里親探しはクールダウン中です",
  	 	 	 	"eng": "Pet adoption is on cooldown"
  	 	 	},
  	 	 	"noSlot": {
- 	 	 	 	"trans": "ペットを飼うにはアパートメントが必要です。",
+ 	 	 	 	"trans": "ペットを飼うにはアパートが必要です。",
  	 	 	 	"eng": "You need to rent a bigger apartment to accommodate more pets"
  	 	 	},
  	 	 	"noItem": {
@@ -10008,16 +10024,16 @@
  	 	 	"eng": "Apartment pet capacity"
  	 	},
  	 	"cooldownTitle": {
- 	 	 	"trans": "採用クールダウン",
+ 	 	 	"trans": "里親探しクールダウン",
  	 	 	"eng": "Adoption Available"
  	 	},
  	 	"buffActivationButton": {
  	 	 	"title": {
- 	 	 	 	"trans": "アドプションバフをアクティブにする",
+ 	 	 	 	"trans": "ペットの里親探しバフをアクティブにする",
  	 	 	 	"eng": "Activate Adoption Buff"
  	 	 	},
  	 	 	"description": {
- 	 	 	 	"trans": "アクティブにすると、バフが有効な間、すべてのプレイヤーがペットを採用できるようになります。",
+ 	 	 	 	"trans": "アクティブにすると、バフが有効な間、すべてのプレイヤーがペットを飼育できるようになります。",
  	 	 	 	"eng": "Activate to allow all players to adopt a pet while buff is active"
  	 	 	},
  	 	 	"buttonText": {
@@ -10031,17 +10047,17 @@
  	 	 	 	}
  	 	 	},
  	 	 	"confirmTitle": {
- 	 	 	 	"trans": "アドプションバフをアクティブにする",
+ 	 	 	 	"trans": "ペットの里親探しバフをアクティブにする",
  	 	 	 	"eng": "Activate Adoption Buff"
  	 	 	},
  	 	 	"confirmDescription": {
- 	 	 	 	"trans": "アドプションバフをアクティブにしますか？",
+ 	 	 	 	"trans": "ペットの里親探しバフをアクティブにしますか？",
  	 	 	 	"eng": "Are you sure you want to activate the Adoption Buff?"
  	 	 	}
  	 	},
  	 	"adoptButton": {
  	 	 	"title": {
- 	 	 	 	"trans": "新しいペットを飼おうぜ",
+ 	 	 	 	"trans": "新しいペットを飼う",
  	 	 	 	"eng": "Adopt a new pet"
  	 	 	}
  	 	}


### PR DESCRIPTION
Update japanese translations.

I think the key/value pair for "monthlySubscription" near line 9262 is not consistent. There should be a translation section for the two words "Monthly Subscription" and "${price} per Month".

The modified image is as follows.

```
---- currently
 	 	"monthlySubscription": {
 	 	 	"trans": "月額サブスクリプション",
 	 	 	"eng": "${price} per Month",
 	 	 	"vars": [
 	 	 	 	"price"
 	 	 	]
 	 	},
 	 	
 ---- Prediction
  	 	"monthlySubscription": {
 	 	 	"trans": "月額サブスクリプション",
 	 	 	"eng": "Monthly Subscription"
 	 	},
  	 	"***Some key string***": {
 	 	 	"vars": [
 	 	 	 	"price"
 	 	 	],
	 	 	"trans": "月額 ${price} USD", <- or JPY??
 	 	 	"eng": "${price} per Month",
 	 	},
```