### PR TITLE
Update fr.json - Fix pop up message loot with too much useless text

### DIFF
--- a/contribution/lang/fr.json
+++ b/contribution/lang/fr.json
@@ -7196,7 +7196,7 @@
 		},
 		"itemv2": {
 			"eng": "You received ${item}",
-			"trans": "... . Let's do: \"Vous avez reçu ${item}\". Another: \"Vous avez obtenu ${item}\". Third: \"Vous venez de recevoir ${item}\". Pick first? maybe second more natural. I'll choose \"Vous avez obtenu ${item}\".<translation>Vous avez obtenu ${item}",
+			"trans": "Tu as obtenu ${item}\",
 			"vars": [
 				"item"
 			]

--- a/contribution/lang/fr.json
+++ b/contribution/lang/fr.json
@@ -7196,7 +7196,7 @@
 		},
 		"itemv2": {
 			"eng": "You received ${item}",
-			"trans": "Tu as obtenu ${item}\",
+			"trans": "Tu as obtenu ${item}",
 			"vars": [
 				"item"
 			]


### PR DESCRIPTION
Chose correct translation and delete useless text in the translation file. It was spamming the screen everytime we looted something.