### PR TITLE
fix: correct 'unkown' to 'unknown' typo in dungeon tile validation (ValidateDungeons.ts:58)

### DIFF
--- a/src/ValidateDungeons.ts
+++ b/src/ValidateDungeons.ts
@@ -55,7 +55,7 @@ export class DungeonValidator {
         }
         for (let i = 0; i < dungeon.tiles.length; ++i) {
             if (dungeon.tiles[i] !== ' ' && dungeon.tiles[i] !== '#') {
-                throw new Error(`Tiles has a unkown character! possible character: " ", "#"`);
+                throw new Error(`Tiles has a unknown character! possible character: " ", "#"`);
             }
             const x = i % this.size;
             const y = Math.floor(i / this.size);


### PR DESCRIPTION
## Summary
Corrects a typo in the user-facing error message thrown when an invalid character is used in dungeon tile maps.

## Change
`src/ValidateDungeons.ts` line 58:
- Before: `throw new Error(\`Tiles has a unkown character! possible character: \" \", \"#\\”\`)`
- After: `throw new Error(\`Tiles has a unknown character! possible character: \" \", \"#\\”\`)`

## Testing
- [x] TypeScript compiles cleanly
- [x] Single commit on feature branch
- [x] User-facing: This error is shown to players who attempt to use invalid characters in dungeon tiles

---
*Submitted via PR攻关 automation.*