### PR TITLE
ci: set explicit read-only GITHUB_TOKEN permissions on JSON validation workflow

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -13,6 +13,9 @@ on:
                 required: true
                 default: "main"
 
+permissions:
+    contents: read
+
 jobs:
     validate:
         runs-on: ubuntu-latest


### PR DESCRIPTION
noticed the JSON_VALIDATION workflow runs with the repo's default GITHUB_TOKEN permissions since it never declares any. the job only checks out the repo, restores the npm cache and runs the validator, so it doesn't need write access to anything. this adds a top-level permissions block with contents: read so the token handed to the run is read-only.

mostly cheap insurance: npm i executes lifecycle scripts from every transitive dependency on each PR, and the current lockfile still pins some pretty old ones (nodemon 2.x tree). if any of those ever ship a bad postinstall, a read-only token means it can't push to the repo. no behavior change for the validation itself.
